### PR TITLE
UNI-1071 Adjustments to borrow modal error messages

### DIFF
--- a/src/components/modals/BorrowModal.jsx
+++ b/src/components/modals/BorrowModal.jsx
@@ -41,7 +41,7 @@ export default function BorrowModal() {
     } else if (inputs.amount.raw.gt(creditLimit)) {
       return Errors.INSUFFICIENT_CREDIT_LIMIT;
     } else if (inputs.amount.raw.lt(minBorrow)) {
-      return `${Errors.MIN_BORROW} (${format(minBorrow)})`;
+      return Errors.MIN_BORROW(minBorrow);
     }
   };
 

--- a/src/components/modals/BorrowModal.jsx
+++ b/src/components/modals/BorrowModal.jsx
@@ -36,10 +36,12 @@ export default function BorrowModal() {
   } = { ...member, ...protocol };
 
   const validate = (inputs) => {
-    if (inputs.amount.raw.gt(creditLimit)) {
+    if (member.isOverdue) {
+      return Errors.IS_OVERDUE;
+    } else if (inputs.amount.raw.gt(creditLimit)) {
       return Errors.INSUFFICIENT_CREDIT_LIMIT;
     } else if (inputs.amount.raw.lt(minBorrow)) {
-      return Errors.MIN_BORROW;
+      return `${Errors.MIN_BORROW} (${format(minBorrow)})`;
     }
   };
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -30,6 +30,7 @@ export const Errors = {
   ALREADY_DELEGATING: "You are already delegating to this address",
   TRUST_LT_LOCKING: "Trust cannot be less than locking",
   EXCEEDED_LOCK: "Amount exceeded locked value",
+  IS_OVERDUE: "You cannot borrow with an overdue balance",
 };
 
 export const ContactsType = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,6 @@
 import { BigNumber, ethers } from "ethers";
 import { chain } from "wagmi";
+import format from "./utils/format";
 
 export const ZERO = BigNumber.from(0);
 
@@ -26,7 +27,7 @@ export const Errors = {
   INVALID_ADDRESS_OR_ENS: "Invalid address or ENS",
   INSUFFICIENT_BALANCE: "Insufficient balance",
   INSUFFICIENT_CREDIT_LIMIT: "Insufficient credit limit",
-  MIN_BORROW: "Amount less than minimum borrow",
+  MIN_BORROW: (amount) => `Amount less than minimum borrow (${format(amount)})`,
   ALREADY_DELEGATING: "You are already delegating to this address",
   TRUST_LT_LOCKING: "Trust cannot be less than locking",
   EXCEEDED_LOCK: "Amount exceeded locked value",


### PR DESCRIPTION
- Added error case if a user is already overdue, therefore unable to borrow
- Display minimum borrow amount if the user is attempting to borrow less than it