### PR TITLE
UNI-1096 Increase the contact details transaction history pagination size

### DIFF
--- a/src/components/contacts/ContactDetails.jsx
+++ b/src/components/contacts/ContactDetails.jsx
@@ -215,7 +215,7 @@ export default function ContactDetails({ contact, setContact, type }) {
               onClose={() => setContact(null)}
             />
             <Modal.Body>{content}</Modal.Body>
-            <TransactionHistory staker={address} pageSize={1} />
+            <TransactionHistory staker={address} pageSize={3} />
           </NoScrollModal>
         </ModalOverlay>
       ) : (


### PR DESCRIPTION
Increased to 3, up from 1. I experimented with 4 transactions but it wasn't ideal for mobiles with a smaller height