### PR TITLE
UNI-1116 Added functionality to format values without rounding

### DIFF
--- a/src/components/credit/CreditStats.jsx
+++ b/src/components/credit/CreditStats.jsx
@@ -53,7 +53,7 @@ export default function CreditStats() {
                 size="large"
                 align="center"
                 label="Available credit"
-                value={<Dai value={format(creditLimit)} />}
+                value={<Dai value={format(creditLimit, 2, false)} />}
               />
               <Stat
                 mt="24px"

--- a/src/components/modals/BorrowModal.jsx
+++ b/src/components/modals/BorrowModal.jsx
@@ -122,7 +122,7 @@ export default function BorrowModal() {
               value={amount.display}
               onChange={register("amount")}
               caption={`Max. ${format(maxBorrow)} DAI`}
-              onCaptionButtonClick={() => setRawValue("amount", maxBorrow)}
+              onCaptionButtonClick={() => setRawValue("amount", maxBorrow, false)}
             />
           </Box>
           {/*--------------------------------------------------------------

--- a/src/components/modals/BorrowModal.jsx
+++ b/src/components/modals/BorrowModal.jsx
@@ -95,7 +95,7 @@ export default function BorrowModal() {
                   size="medium"
                   align="center"
                   label="Available credit"
-                  value={<Dai value={format(creditLimit)} />}
+                  value={<Dai value={format(creditLimit, 2, false)} />}
                 />
               </Grid.Col>
               <Grid.Col>

--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -10,7 +10,8 @@ const empty = {
   raw: ZERO,
 };
 
-const formatValue = (value) => format(value).replace(/\,/g, "");
+const formatValue = (value, rounded) =>
+  format(value, 2, rounded).replace(/\,/g, "");
 
 export default function useForm(props = {}) {
   const { validate } = props;
@@ -18,7 +19,7 @@ export default function useForm(props = {}) {
   const [values, setValues] = useState();
   const [errors, setErrors] = useState();
 
-  const setNumber = (name, value, type) => {
+  const setNumber = (name, value, type, rounded) => {
     let newValues;
 
     if (!value) {
@@ -29,7 +30,7 @@ export default function useForm(props = {}) {
       const parsed =
         type === "display"
           ? { raw: parseUnits(toFixed(value)), display: value }
-          : { raw: value, display: formatValue(value) };
+          : { raw: value, display: formatValue(value, rounded) };
 
       newValues = { ...values, [name]: parsed };
     }
@@ -47,16 +48,16 @@ export default function useForm(props = {}) {
     setValues(newValues);
   };
 
-  const setValue = (name, display, type) => {
+  const setValue = (name, display, type, rounded = true) => {
     if (type === "number") {
-      setNumber(name, display, "display");
+      setNumber(name, display, "display", rounded);
     } else {
       setSimple(name, display);
     }
   };
 
-  const setRawValue = (name, raw) => {
-    setNumber(name, raw, "raw");
+  const setRawValue = (name, raw, rounded = true) => {
+    setNumber(name, raw, "raw", rounded);
   };
 
   const register = (name) => (event) => {

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,21 +1,26 @@
 import { formatUnits } from "ethers/lib/utils";
 
-export default function format(n, digits = 2) {
+export default function format(n, digits = 2, rounded = true) {
   if (!n) n = "0";
-  return commify(Number(formatUnits(n)), digits);
+  return commify(Number(formatUnits(n)), digits, rounded);
 }
 
-function commify(num, digits) {
+function commify(num, digits, rounded = true) {
   num = Number(num);
   num = num <= 0 ? 0 : num;
 
   if (!num) return `0${digits > 0 ? "." : ""}${"".padEnd(digits, "0")}`;
 
-  const numStr = Number(num).toLocaleString("en", {
+  let numStr = Number(num).toLocaleString("en", {
     useGrouping: false,
-    minimumFractionDigits: digits,
-    maximumFractionDigits: digits,
+    minimumFractionDigits: rounded ? digits : 18,
+    maximumFractionDigits: rounded ? digits : 18,
   });
+
+  if (!rounded) {
+    const pattern = new RegExp("^-?\\d+(?:\\.\\d{0," + digits + "})?");
+    numStr = numStr.match(pattern)[0];
+  }
 
   const parts = numStr.split(".");
 


### PR DESCRIPTION
By default, the `.toLocaleString()` function used when formatting performs rounding of the number when set to 2 digits. This PR contains changes that adds a `rounded` paramater to the `format()` function allowing it to be formatted without rounding.