### PR TITLE
UNI-1141 Fixed maximum repay calculation

### DIFF
--- a/src/components/modals/RepayModal.jsx
+++ b/src/components/modals/RepayModal.jsx
@@ -87,7 +87,7 @@ export default function RepayModal() {
     },
     {
       display: format(daiBalance.lt(owed) ? daiBalance : owed),
-      value: daiBalance.eq(0) ? ZERO : ethers.constants.MaxUint256,
+      value: daiBalance.lt(owed) ? daiBalance : ethers.constants.MaxUint256,
       paymentType: PaymentType.MAX,
       title: maxRepay.gte(owed)
         ? "Pay-off entire loan"


### PR DESCRIPTION
The previous calculation was causing issues if the users DAI balance was less than the amount they owed. This has been reworked to allow a maximum repay to still be processed as expected.