### PR TITLE
UNI-1140 Borrowing max doesnt borrow max

### DIFF
--- a/src/utils/numbers.js
+++ b/src/utils/numbers.js
@@ -1,4 +1,5 @@
-import { BlocksPerYear, WAD, ZERO } from "constants";
+import { BlocksPerYear, ZERO } from "constants";
+import { BigNumber } from "ethers";
 import { parseEther } from "ethers/lib/utils";
 
 export const min = (a, b) => {
@@ -46,8 +47,9 @@ export function toFixed(x) {
 }
 
 export const calculateMaxBorrow = (creditLimit, originationFee) => {
-  const borrowFee = creditLimit.mul(originationFee).div(WAD);
-  return creditLimit.sub(borrowFee);
+  const cl = Number(creditLimit.mul(99999).div(100000).toString());
+  const ofe = Number(originationFee.toString()) / 1e18;
+  return BigNumber.from(toFixed(Math.floor(cl / (ofe + 1)).toString()));
 };
 
 export const calculateMinPayment = (interest) => {

--- a/src/utils/numbers.js
+++ b/src/utils/numbers.js
@@ -1,5 +1,4 @@
-import { BlocksPerYear, ZERO } from "constants";
-import { BigNumber } from "ethers";
+import { BlocksPerYear, WAD, ZERO } from "constants";
 import { parseEther } from "ethers/lib/utils";
 
 export const min = (a, b) => {
@@ -47,9 +46,8 @@ export function toFixed(x) {
 }
 
 export const calculateMaxBorrow = (creditLimit, originationFee) => {
-  const cl = Number(creditLimit.mul(99999).div(100000).toString());
-  const ofe = Number(originationFee.toString()) / 1e18;
-  return BigNumber.from(toFixed(Math.floor(cl / (ofe + 1)).toString()));
+  const borrowFee = creditLimit.mul(originationFee).div(WAD);
+  return creditLimit.sub(borrowFee);
 };
 
 export const calculateMinPayment = (interest) => {

--- a/src/utils/numbers.js
+++ b/src/utils/numbers.js
@@ -47,7 +47,7 @@ export function toFixed(x) {
 }
 
 export const calculateMaxBorrow = (creditLimit, originationFee) => {
-  const cl = Number(creditLimit.mul(9999).div(10000).toString());
+  const cl = Number(creditLimit.mul(9990).div(10000).toString());
   const ofe = Number(originationFee.toString()) / 1e18;
   return BigNumber.from(toFixed(Math.floor(cl / (ofe + 1)).toString()));
 };

--- a/src/utils/numbers.js
+++ b/src/utils/numbers.js
@@ -47,7 +47,7 @@ export function toFixed(x) {
 }
 
 export const calculateMaxBorrow = (creditLimit, originationFee) => {
-  const cl = Number(creditLimit.mul(99999).div(100000).toString());
+  const cl = Number(creditLimit.mul(9999).div(10000).toString());
   const ofe = Number(originationFee.toString()) / 1e18;
   return BigNumber.from(toFixed(Math.floor(cl / (ofe + 1)).toString()));
 };


### PR DESCRIPTION
I've reworked the `calculateMaxBorrow()` function to use floating point math. This should prevent the total borrow amount being greater than the users credit limit after factoring in the fee, but it comes at the trade off of not being as close to the users available credit limit.