### PR TITLE
UNI-1163 ManageContactModal contact state not updating after contract write

### DIFF
--- a/src/components/modals/EditVouch.jsx
+++ b/src/components/modals/EditVouch.jsx
@@ -29,9 +29,9 @@ export default function EditVouchModal({ address }) {
 
   const { locking = ZERO, trust = ZERO } = vouchee;
 
-  const back = () =>
+  const back = (contact) =>
     open(MANAGE_CONTACT_MODAL, {
-      contact: vouchee,
+      contact: contact,
       type: ContactsType.VOUCHEES,
     });
 
@@ -51,8 +51,11 @@ export default function EditVouchModal({ address }) {
     args: [address, amount.raw],
     enabled: amount.raw.gte(locking),
     onComplete: async () => {
-      await refetchVouchees();
-      back();
+      const response = await refetchVouchees();
+      const contact = response.data.find((c) =>
+        compareAddresses(c.address, address)
+      );
+      back(contact);
     },
   });
 

--- a/src/components/modals/WriteOffDebtModal.jsx
+++ b/src/components/modals/WriteOffDebtModal.jsx
@@ -31,9 +31,9 @@ export default function WriteOffDebtModal({ address }) {
 
   const { locking = ZERO, vouch = ZERO, isOverdue } = vouchee || {};
 
-  const back = () =>
+  const back = (contact) =>
     open(MANAGE_CONTACT_MODAL, {
-      contact: vouchee,
+      contact: contact,
       type: ContactsType.VOUCHEES,
     });
 
@@ -59,8 +59,11 @@ export default function WriteOffDebtModal({ address }) {
     args: [vouchee.address, amount.raw],
     enabled: isOverdue && vouchee?.address && amount.raw.gt(ZERO),
     onComplete: async () => {
-      await refetchVouchees();
-      back();
+      const response = await refetchVouchees();
+      const contact = response.data.find((c) =>
+        compareAddresses(c.address, address)
+      );
+      back(contact);
     },
   });
 


### PR DESCRIPTION
After calling `refetchVouchees()` the `vouchee` variable was not being updated before before the `back()` function was called. I've managed to work around this for now by directly parsing the `refetchVouchees()` response for the updated `vouchee` but a better solution may be possible.