### PR TITLE
UNI-1174 Stop member listener throwing errors when no wallet is connected

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,7 +17,7 @@ import Cache from "providers/Cache";
 import Header from "components/shared/Header";
 import { general as generalRoutes } from "App.routes";
 import ScrollToTop from "components/misc/ScrollToTop";
-import { MemberListener } from "hooks/useMemberListener";
+import useMemberListener from "hooks/useMemberListener";
 
 /**
  * Shim component that checks if the App is ready
@@ -31,6 +31,8 @@ function AppReadyShim({ children }) {
   const { appReady, setAppReady } = useAppNetwork();
 
   const isGeneralRoute = Boolean(matchRoutes(generalRoutes, location));
+
+  useMemberListener();
 
   useEffect(() => {
     // If the member is a member then skip the connect/ready page
@@ -105,7 +107,6 @@ export default function App() {
                             <AppReadyShim>
                               {appReady ? (
                                 <>
-                                  {isConnected && <MemberListener />}
                                   <Header />
                                   <Routes />
                                 </>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,7 +17,7 @@ import Cache from "providers/Cache";
 import Header from "components/shared/Header";
 import { general as generalRoutes } from "App.routes";
 import ScrollToTop from "components/misc/ScrollToTop";
-import useMemberListener from "hooks/useMemberListener";
+import { MemberListener } from "hooks/useMemberListener";
 
 /**
  * Shim component that checks if the App is ready
@@ -31,8 +31,6 @@ function AppReadyShim({ children }) {
   const { appReady, setAppReady } = useAppNetwork();
 
   const isGeneralRoute = Boolean(matchRoutes(generalRoutes, location));
-
-  useMemberListener();
 
   useEffect(() => {
     // If the member is a member then skip the connect/ready page
@@ -107,6 +105,7 @@ export default function App() {
                             <AppReadyShim>
                               {appReady ? (
                                 <>
+                                  {isConnected && <MemberListener />}
                                   <Header />
                                   <Routes />
                                 </>

--- a/src/components/governance/GovernanceStats.jsx
+++ b/src/components/governance/GovernanceStats.jsx
@@ -21,7 +21,7 @@ const getAnalyticsUrl = (chainId) => {
 export default function GovernaceStats() {
   const { chain } = useNetwork();
   const { data: protocol = {} } = useProtocol();
-  const analyticsUrl = getAnalyticsUrl(chain.id);
+  const analyticsUrl = getAnalyticsUrl(chain?.id);
 
   const {
     totalStaked = ZERO,
@@ -60,7 +60,7 @@ export default function GovernaceStats() {
               />
             </Grid.Col>
             <Grid.Col xs={6}>
-              {protocol.borrowRatePerBlock && (
+              {chain && protocol.borrowRatePerBlock && (
                 <Stat
                   mt="32px"
                   align="center"

--- a/src/components/governance/GovernanceStats.jsx
+++ b/src/components/governance/GovernanceStats.jsx
@@ -27,6 +27,7 @@ export default function GovernaceStats() {
     totalStaked = ZERO,
     totalBorrows = ZERO,
     getLoanableAmount = ZERO,
+    borrowRatePerBlock = ZERO,
   } = protocol;
 
   return (
@@ -60,16 +61,13 @@ export default function GovernaceStats() {
               />
             </Grid.Col>
             <Grid.Col xs={6}>
-              {chain && protocol.borrowRatePerBlock && (
+              {chain && borrowRatePerBlock && (
                 <Stat
                   mt="32px"
                   align="center"
                   label="Interest rate"
                   value={`${format(
-                    calculateInterestRate(
-                      protocol.borrowRatePerBlock,
-                      chain.id
-                    ).mul(100)
+                    calculateInterestRate(borrowRatePerBlock, chain.id).mul(100)
                   )}%`}
                 />
               )}

--- a/src/hooks/useMemberListener.js
+++ b/src/hooks/useMemberListener.js
@@ -4,6 +4,18 @@ import useContract from "hooks/useContract";
 import { useMember } from "providers/MemberData";
 import { useVouchers } from "providers/VouchersData";
 
+// The useContract() calls in useMemberListener() return undefined
+// when no chain is connected causing the useContractEvent() hooks to fail.
+//
+// It looks like this behaviour is fixed in recent wagmi versions but
+// as a workaround until we upgrade this component allows us to conditionally
+// listen for the contract events.
+export const MemberListener = ({ children }) => {
+  useMemberListener();
+
+  return <>{children}</>;
+};
+
 export default function useMemberListener() {
   const { address } = useAccount();
   const { refetch: refetchMember } = useMember();

--- a/src/hooks/useMemberListener.js
+++ b/src/hooks/useMemberListener.js
@@ -1,28 +1,23 @@
-import { useAccount, useContractEvent } from "wagmi";
+import { chain, useAccount, useContractEvent, useNetwork } from "wagmi";
 
 import useContract from "hooks/useContract";
 import { useMember } from "providers/MemberData";
 import { useVouchers } from "providers/VouchersData";
 
-// The useContract() calls in useMemberListener() return undefined
-// when no chain is connected causing the useContractEvent() hooks to fail.
-//
-// It looks like this behaviour is fixed in recent wagmi versions but
-// as a workaround until we upgrade this component allows us to conditionally
-// listen for the contract events.
-export const MemberListener = ({ children }) => {
-  useMemberListener();
-
-  return <>{children}</>;
-};
-
 export default function useMemberListener() {
   const { address } = useAccount();
+  const { chain: connectedChain } = useNetwork();
   const { refetch: refetchMember } = useMember();
   const { refetch: refetchVouchers } = useVouchers();
 
-  const userManager = useContract("userManager");
-  const daiContract = useContract("dai");
+  const userManager = useContract(
+    "userManager",
+    connectedChain?.id ?? chain.mainnet.id
+  );
+  const daiContract = useContract(
+    "dai",
+    connectedChain?.id ?? chain.mainnet.id
+  );
 
   const refreshMember = () => {
     console.log("Listener: refreshing member");


### PR DESCRIPTION
The `useContract()` calls in `useMemberListener()` return undefined when no chain is connected causing the `useContractEvent()` hooks to throw errors.

It looks like this [useContractEvent](https://wagmi.sh/react/hooks/useContractEvent) behavior is fixed in recent wagmi versions as the hook will just not run if these parameters do not exist. This hook (and presumably others) have different semantics in the new version, so it's not a quick change to upgrade. As workaround until we get around to upgrading, I've implemented a `MemberListener` component allowing us to conditionally listen for the contract events.