### PR TITLE
UNI-1180 Fixed union balance progress calculation

### DIFF
--- a/src/components/register/StakeStep.jsx
+++ b/src/components/register/StakeStep.jsx
@@ -43,7 +43,7 @@ export default function StakeStep() {
 
   const percentage = unionBalance.gte(WAD)
     ? 100
-    : Number(unionBalance.div(WAD));
+    : Number(unionBalance.mul(100).div(WAD));
 
   const effectiveTotalStake = totalStaked.sub(totalFrozen);
 


### PR DESCRIPTION
Fixed an issue where the calculation was not correctly calculating the percentage progress of union balances less than 1.