### PR TITLE
UNI-1173 Profile governance stats showing incorrect data

### DIFF
--- a/src/components/profile/ProfileGovernanceStats.jsx
+++ b/src/components/profile/ProfileGovernanceStats.jsx
@@ -3,10 +3,10 @@ import { ReactComponent as TooltipIcon } from "@unioncredit/ui/lib/icons/tooltip
 
 import { ZERO } from "constants";
 import format from "utils/format";
-import { useMember } from "providers/MemberData";
+import { useMemberData } from "providers/MemberData";
 
-export default function ProfileGovernanceStats() {
-  const { data: member = {} } = useMember();
+export default function ProfileGovernanceStats({ address, chainId }) {
+  const { data: member = {} } = useMemberData(address, chainId);
 
   const { unionBalance = ZERO, votes = ZERO } = member;
 

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -213,7 +213,10 @@ function ProfileInner({ profileMember = {}, connectedMember = {}, chainId }) {
           </Grid>
           <Divider my="24px" />
           <Heading mb="24px">Governance</Heading>
-          <ProfileGovernanceStats />
+          <ProfileGovernanceStats
+            address={address}
+            chainId={connectedChain.id}
+          />
         </Card.Body>
       </Card>
     </Box>


### PR DESCRIPTION
Fixed an issue where the profile governance stats component was showing the connected users data instead of the data of the user profile being viewed. 