### PR TITLE
fix: repair DistributionBar values (group separators + missing token arg)

### DIFF
--- a/src/components/profile/ProfileCurrentBalances.jsx
+++ b/src/components/profile/ProfileCurrentBalances.jsx
@@ -75,11 +75,11 @@ export const ProfileCurrentBalances = ({ address, chainId, vouchees, vouchers })
           m="18px 0"
           items={[
             {
-              value: formattedNumber(owed),
+              value: formattedNumber(owed, token),
               color: "blue900",
             },
             {
-              value: formattedNumber(vouch - owed, 2, false),
+              value: formattedNumber(vouch - owed, token, 2, false),
               color: "blue50",
             },
           ]}

--- a/src/components/profile/ProfileSidebar.jsx
+++ b/src/components/profile/ProfileSidebar.jsx
@@ -47,15 +47,15 @@ export function ProfileSidebar({ address, member, chainId }) {
             m="24px 0"
             items={[
               {
-                value: formattedNumber(owed),
+                value: formattedNumber(owed, token),
                 color: "blue900",
               },
               {
-                value: formattedNumber(creditLimit, 2, false),
+                value: formattedNumber(creditLimit, token, 2, false),
                 color: "blue100",
               },
               {
-                value: formattedNumber(unavailableBalance),
+                value: formattedNumber(unavailableBalance, token),
                 color: "amber500",
               },
             ]}

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -17,7 +17,10 @@ export default function format(
 }
 
 export const formattedNumber = (n, token, digits = 2, rounded = true) => {
-  return parseFloat(format(n, token, digits, rounded, false, false).replace(",", ""));
+  // Strip ALL group separators: `format` returns e.g. "1,234,567.89", and
+  // replacing only the first comma left "1234,567.89", which parseFloat
+  // truncates to 1234 (~1000x low) for every value >= 1,000,000.
+  return parseFloat(format(n, token, digits, rounded, false, false).replace(/,/g, ""));
 };
 
 export const compactFormattedNumber = (n, token) => {

--- a/src/utils/format.test.js
+++ b/src/utils/format.test.js
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { parseUnits } from "viem";
+
+import format, { formattedNumber } from "utils/format";
+
+const usdc = (s) => parseUnits(s, 6); // USDC / 6dp (Base, Optimism)
+const dai = (s) => parseUnits(s, 18); // DAI / UNION / 18dp
+
+describe("formattedNumber", () => {
+  it("is exact below the first group separator", () => {
+    expect(formattedNumber(usdc("1"), "USDC")).toBe(1);
+    expect(formattedNumber(usdc("100.5"), "USDC")).toBe(100.5);
+    expect(formattedNumber(usdc("999.99"), "USDC")).toBe(999.99);
+  });
+
+  it("is exact with one group separator", () => {
+    expect(formattedNumber(usdc("1500"), "USDC")).toBe(1500);
+    expect(formattedNumber(usdc("999999.99"), "USDC")).toBe(999999.99);
+  });
+
+  // Regression: `format` returns a commified string and formattedNumber used
+  // `.replace(",", "")`, which strips only the FIRST comma — "1,234,567.89"
+  // became "1234,567.89" and parseFloat truncated it to 1234 (~1000x low).
+  // These are the values that were broken; everything under 1,000,000 was fine.
+  it("does not truncate at or above 1,000,000 (multiple group separators)", () => {
+    expect(formattedNumber(usdc("1000000"), "USDC")).toBe(1000000);
+    expect(formattedNumber(usdc("1234567.89"), "USDC")).toBe(1234567.89);
+    expect(formattedNumber(usdc("5000000"), "USDC")).toBe(5000000);
+    expect(formattedNumber(dai("1234567.89"), "DAI")).toBe(1234567.89);
+    // Billions: three separators — would have collapsed to 1 before the fix.
+    expect(formattedNumber(dai("1000000000"), "UNION")).toBe(1000000000);
+  });
+
+  // Guards the ProfileSidebar / ProfileCurrentBalances bug: those call sites
+  // passed a number into the `token` slot (arg-order slip), so the amount was
+  // scaled by the wrong number of decimals and collapsed to 0, which made the
+  // DistributionBar render empty. The token argument is what keeps 6dp markets
+  // from being read as 18dp.
+  it("scales by the token's decimals, not a default", () => {
+    // Same on-chain magnitude, different token decimals.
+    expect(formattedNumber(usdc("1500"), "USDC")).toBe(1500);
+    expect(formattedNumber(dai("1500"), "DAI")).toBe(1500);
+
+    // A 6dp amount read as 18dp (the old `formattedNumber(owed)` default)
+    // underflows to 0 — this is what blanked the profile bars.
+    expect(formattedNumber(usdc("1500"), "DAI")).toBe(0);
+
+    // An omitted/invalid token also yields 0 rather than the real value, so
+    // call sites must always pass it.
+    expect(formattedNumber(usdc("1500"))).toBe(0);
+    expect(formattedNumber(usdc("1500"), 2, false)).toBe(0);
+  });
+
+  it("handles zero and dust", () => {
+    expect(formattedNumber(0n, "USDC")).toBe(0);
+    expect(formattedNumber(undefined, "USDC")).toBe(0);
+  });
+});
+
+describe("format", () => {
+  it("commifies and respects token decimals", () => {
+    expect(format(usdc("1234567.89"), "USDC")).toBe("1,234,567.89");
+    expect(format(dai("1500"), "DAI")).toBe("1,500.00");
+  });
+
+  it("truncates instead of rounding when rounded=false", () => {
+    // Used for "available to borrow" style figures that must not round up.
+    expect(format(usdc("100.999"), "USDC", 2, false)).toBe("100.99");
+    expect(format(usdc("100.999"), "USDC", 2, true)).toBe("101.00");
+  });
+});


### PR DESCRIPTION
## Summary
Fixes two bugs that left the profile **DistributionBar** blank and distorted large-balance bars.

**Scope note:** neither bug affected the *numbers* on screen — those come from `format()` directly and were always correct. Only bar segment proportions were wrong. (Verified: profiles showing a `$115` credit limit rendered a bar with zero-width segments.)

## 1. `formattedNumber` stripped only the first group separator
`.replace(",", "")` turned `"1,234,567.89"` into `"1234,567.89"`, which `parseFloat` truncates to **1234** (~1000× low). Anything below 1,000,000 has a single comma and worked fine — which is why this went unnoticed.

```
before:  1,234,567.89 -> 1234        5,000,000 -> 5000
after:   1,234,567.89 -> 1234567.89  5,000,000 -> 5000000
```

## 2. Profile call sites passed a number into the `token` slot
Signature is `(n, token, digits, rounded)`, but the call sites were:

```js
formattedNumber(owed)                    // token undefined -> scaled as 18dp DAI
formattedNumber(creditLimit, 2, false)   // token = 2 -> UNIT[2] is undefined
```

On 6dp USDC markets (Base/Optimism) both collapse to **0**, so every segment was 0 and `DistributionBar` fell back to its `empty` state on **every profile page**. Both files already had `token` in scope — fixed in `ProfileSidebar.jsx` and `ProfileCurrentBalances.jsx`.

Confirmed against production before the fix:

| Profile | Displayed text | Bar |
|---|---|---|
| a known member | Credit limit **$115**, owed **$0** | `DistributionBar empty`, widths **[0, 0]** |
| another member | Credit limit **$35**, owed **$1** | `DistributionBar empty`, widths **[0, 0]** |

## Tests
Adds `src/utils/format.test.js` (7 tests): exactness below/at/above the 1,000,000 boundary (incl. billions), token-decimal scaling (6dp vs 18dp), truncate-vs-round, and zero/undefined handling.

**These are real guards, not tautologies** — I re-ran them against the old implementation and the boundary test fails (`expected 1000 to be 1000000`), then passes after the fix.

## Verification
- `yarn test` → **11/11 pass** (7 new + 4 existing)
- `yarn build` → clean
- Post-deploy I'll re-run the production DOM check to confirm the bar renders non-empty

## Follow-up (not in this PR)
A component-level test for `ProfileSidebar` would guard the call shape directly; it needs a fair amount of provider mocking, so bug #2 is guarded here by the unit tests on decimals plus the empirical DOM check.
