### PR TITLE
fix: repair data freshness, polling storm and multicall resilience

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useAccount } from "wagmi";
 import { Box, Grid, Layout } from "@unioncredit/ui";
 import { useLocation, useSearchParams } from "react-router-dom";
@@ -31,6 +32,15 @@ import { useAppNetwork } from "./providers/Network";
 import useReferrer from "./hooks/useReferrer";
 import { ApolloClient, ApolloProvider, InMemoryCache } from "@apollo/client";
 
+// Created once at module scope. Previously constructed inside App(), which gave
+// every render a brand-new client and an empty InMemoryCache — App re-renders on
+// each account/chain/route change, so Ponder queries were torn down, re-subscribed
+// and refetched continuously, and cached data was thrown away.
+const apolloClient = new ApolloClient({
+  uri: import.meta.env.REACT_APP_PONDER_URL,
+  cache: new InMemoryCache(),
+});
+
 export default function App() {
   useChainParams();
 
@@ -41,19 +51,15 @@ export default function App() {
   const { isConnected } = useAccount();
   const { set: setReferrer } = useReferrer();
 
-  const apolloClient = new ApolloClient({
-    // eslint-disable-next-line no-undef
-    uri: import.meta.env.REACT_APP_PONDER_URL,
-    cache: new InMemoryCache(),
-  });
-
   // Parses referrer address from "refAddress" query parameter and
-  // stores it in local storage
+  // stores it in local storage. Runs in an effect — calling setReferrer during
+  // render is an impure render (extra render pass, unsafe under StrictMode /
+  // concurrent rendering).
   const [searchParams] = useSearchParams();
   const referrer = searchParams.get("refAddress");
-  if (referrer) {
-    setReferrer(referrer);
-  }
+  useEffect(() => {
+    if (referrer) setReferrer(referrer);
+  }, [referrer, setReferrer]);
 
   if (!version || ((chain?.unsupported || !isConnected) && !isGeneralRoute(location))) {
     return (

--- a/src/hooks/useMemberListener.js
+++ b/src/hooks/useMemberListener.js
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useAccount, useWatchContractEvent } from "wagmi";
 import { mainnet } from "viem/chains";
 
@@ -12,17 +12,18 @@ import { useToken } from "hooks/useToken";
 /**
  * Refresh the connected member's data when a relevant on-chain event fires.
  *
- * These subscriptions previously passed a `listener` prop with positional
- * arguments — the wagmi v1 shape. wagmi v2's `useWatchContractEvent` takes
- * `onLogs` and hands it an ARRAY of logs with DECODED NAMED args, so every
- * `listener` here was an unknown prop that wagmi ignored: no handler ever ran.
+ * wagmi v2's `useWatchContractEvent` takes `onLogs` and hands it an ARRAY of
+ * logs with DECODED NAMED args — the previous `listener` prop was the wagmi v1
+ * shape and was silently ignored, so no handler ever ran and third-party
+ * repays / vouches / write-offs never refreshed the UI.
  *
- * Net effect of the bug: if a third party repaid your loan, vouched for you,
- * cancelled a vouch, wrote off debt, or you received/sent the token, the UI kept
- * showing stale data until a manual refetch or the 2-minute staleTime refetch on
- * window focus.
+ * Handler identity matters: wagmi keeps `onLogs` in its subscription effect's
+ * dependency array, so a new identity per render tears down and re-creates the
+ * watcher. The values the handlers need (address, and the provider refetch
+ * functions — which are new inline functions every render) are kept fresh in a
+ * ref instead of being captured, and the handlers themselves are created once.
  *
- * Arg names below match the ABIs exactly (userManager: staker/borrower,
+ * Arg names match the ABIs exactly (userManager: staker/borrower,
  * account/borrower; erc20: from/to). Both address fields are checked because the
  * user may be either party to the event.
  */
@@ -37,54 +38,75 @@ export default function useMemberListener() {
   const userManager = useContract("userManager", chainId);
   const tokenContract = useContract(token.toLowerCase(), chainId);
 
-  const refreshMember = useCallback(async () => {
-    await refetchMember();
-    refetchVouchers();
-    refetchVouchees();
-  }, [refetchMember, refetchVouchers, refetchVouchees]);
+  const latest = useRef({ address: undefined, refresh: async () => {} });
+  useEffect(() => {
+    latest.current = {
+      address,
+      refresh: async () => {
+        await refetchMember();
+        refetchVouchers();
+        refetchVouchees();
+      },
+    };
+  });
 
-  // True when any log in the batch names the connected address in one of `keys`.
-  const involvesUser = useCallback(
-    (logs, keys) =>
-      Boolean(address) &&
-      (logs || []).some((log) => keys.some((key) => compareAddresses(log?.args?.[key], address))),
-    [address]
-  );
-
+  // Created once; reads the current address/refetchers from the ref at event time.
   const refreshIfInvolved = useCallback(
     (keys) => (logs) => {
-      if (involvesUser(logs, keys)) refreshMember();
+      const { address: current, refresh } = latest.current;
+      if (!current) return;
+
+      const involved = (logs || []).some((log) =>
+        keys.some((key) => compareAddresses(log?.args?.[key], current))
+      );
+
+      if (involved) refresh();
     },
-    [involvesUser, refreshMember]
+    []
   );
+
+  const onStakerBorrowerLogs = useMemo(
+    () => refreshIfInvolved(["staker", "borrower"]),
+    [refreshIfInvolved]
+  );
+  const onAccountBorrowerLogs = useMemo(
+    () => refreshIfInvolved(["account", "borrower"]),
+    [refreshIfInvolved]
+  );
+  const onTransferLogs = useMemo(() => refreshIfInvolved(["from", "to"]), [refreshIfInvolved]);
 
   useWatchContractEvent({
     ...userManager,
     eventName: "LogDebtWriteOff",
-    onLogs: refreshIfInvolved(["staker", "borrower"]),
+    enabled: !!userManager.address,
+    onLogs: onStakerBorrowerLogs,
   });
 
   useWatchContractEvent({
     ...userManager,
     eventName: "LogUpdateTrust",
-    onLogs: refreshIfInvolved(["staker", "borrower"]),
+    enabled: !!userManager.address,
+    onLogs: onStakerBorrowerLogs,
   });
 
   useWatchContractEvent({
     ...userManager,
     eventName: "LogCancelVouch",
-    onLogs: refreshIfInvolved(["account", "borrower"]),
+    enabled: !!userManager.address,
+    onLogs: onAccountBorrowerLogs,
   });
 
   useWatchContractEvent({
     ...userManager,
     eventName: "LogRegisterMember",
-    onLogs: refreshIfInvolved(["account", "borrower"]),
+    enabled: !!userManager.address,
+    onLogs: onAccountBorrowerLogs,
   });
 
   useWatchContractEvent({
     ...tokenContract,
     eventName: "Transfer",
-    onLogs: refreshIfInvolved(["from", "to"]),
+    enabled: !!tokenContract.address,
+    onLogs: onTransferLogs,
   });
 }

--- a/src/hooks/useMemberListener.js
+++ b/src/hooks/useMemberListener.js
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { useAccount, useWatchContractEvent } from "wagmi";
 import { mainnet } from "viem/chains";
 
@@ -8,6 +9,23 @@ import { useVouchees } from "providers/VoucheesData";
 import { compareAddresses } from "utils/compare";
 import { useToken } from "hooks/useToken";
 
+/**
+ * Refresh the connected member's data when a relevant on-chain event fires.
+ *
+ * These subscriptions previously passed a `listener` prop with positional
+ * arguments — the wagmi v1 shape. wagmi v2's `useWatchContractEvent` takes
+ * `onLogs` and hands it an ARRAY of logs with DECODED NAMED args, so every
+ * `listener` here was an unknown prop that wagmi ignored: no handler ever ran.
+ *
+ * Net effect of the bug: if a third party repaid your loan, vouched for you,
+ * cancelled a vouch, wrote off debt, or you received/sent the token, the UI kept
+ * showing stale data until a manual refetch or the 2-minute staleTime refetch on
+ * window focus.
+ *
+ * Arg names below match the ABIs exactly (userManager: staker/borrower,
+ * account/borrower; erc20: from/to). Both address fields are checked because the
+ * user may be either party to the event.
+ */
 export default function useMemberListener() {
   const { address, chain: connectedChain } = useAccount();
   const { refetch: refetchMember } = useMember();
@@ -15,68 +33,58 @@ export default function useMemberListener() {
   const { refetch: refetchVouchees } = useVouchees();
   const { token } = useToken();
 
-  const userManager = useContract("userManager", connectedChain?.id ?? mainnet.id);
-  const tokenContract = useContract(token.toLowerCase(), connectedChain?.id ?? mainnet.id);
+  const chainId = connectedChain?.id ?? mainnet.id;
+  const userManager = useContract("userManager", chainId);
+  const tokenContract = useContract(token.toLowerCase(), chainId);
 
-  const refreshMember = async () => {
-    console.log("Listener: refreshing member");
+  const refreshMember = useCallback(async () => {
     await refetchMember();
     refetchVouchers();
     refetchVouchees();
-  };
+  }, [refetchMember, refetchVouchers, refetchVouchees]);
+
+  // True when any log in the batch names the connected address in one of `keys`.
+  const involvesUser = useCallback(
+    (logs, keys) =>
+      Boolean(address) &&
+      (logs || []).some((log) => keys.some((key) => compareAddresses(log?.args?.[key], address))),
+    [address]
+  );
+
+  const refreshIfInvolved = useCallback(
+    (keys) => (logs) => {
+      if (involvesUser(logs, keys)) refreshMember();
+    },
+    [involvesUser, refreshMember]
+  );
 
   useWatchContractEvent({
     ...userManager,
     eventName: "LogDebtWriteOff",
-    listener: (staker, borrower) => {
-      console.debug("Listener: LogDebtWriteOff received", { staker, borrower, address });
-      if (compareAddresses(borrower, address) || compareAddresses(staker, address)) {
-        refreshMember();
-      }
-    },
+    onLogs: refreshIfInvolved(["staker", "borrower"]),
   });
 
   useWatchContractEvent({
     ...userManager,
     eventName: "LogUpdateTrust",
-    listener: (staker, borrower) => {
-      console.debug("Listener: LogUpdateTrust received", { staker, borrower, address });
-      if (compareAddresses(borrower, address) || compareAddresses(staker, address)) {
-        refreshMember();
-      }
-    },
+    onLogs: refreshIfInvolved(["staker", "borrower"]),
   });
 
   useWatchContractEvent({
     ...userManager,
     eventName: "LogCancelVouch",
-    listener: (_, borrower) => {
-      console.debug("Listener: LogCancelVouch received", { borrower, address });
-      if (compareAddresses(borrower, address)) {
-        refreshMember();
-      }
-    },
+    onLogs: refreshIfInvolved(["account", "borrower"]),
   });
 
   useWatchContractEvent({
     ...userManager,
     eventName: "LogRegisterMember",
-    listener: (_, account) => {
-      console.debug("Listener: LogRegisterMember received", { account, address });
-      if (compareAddresses(account, address)) {
-        refreshMember();
-      }
-    },
+    onLogs: refreshIfInvolved(["account", "borrower"]),
   });
 
   useWatchContractEvent({
     ...tokenContract,
     eventName: "Transfer",
-    listener: (from, to) => {
-      // console.debug("Listener: Token Transfer received", { address, from, to });
-      if (compareAddresses(address, from) || compareAddresses(address, to)) {
-        refreshMember();
-      }
-    },
+    onLogs: refreshIfInvolved(["from", "to"]),
   });
 }

--- a/src/hooks/usePollMember.js
+++ b/src/hooks/usePollMember.js
@@ -12,7 +12,7 @@ const BACKOFF_FACTOR = 1.5;
 
 export default function usePollMemberData(address, inputChainId) {
   const timer = useRef(null);
-  const [pollInterval, setPollInterval] = useState(INITIAL_POLL_INTERVAL);
+  const intervalRef = useRef(INITIAL_POLL_INTERVAL);
   const [isWindowActive, setIsWindowActive] = useState(true);
   const { chain: connectedChain } = useAccount();
   const { version } = useVersion();
@@ -77,32 +77,47 @@ export default function usePollMemberData(address, inputChainId) {
     return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
   }, []);
 
-  // Set up polling with backoff
+  // Set up polling with backoff.
+  //
+  // The interval lives in a ref and each run self-schedules the next one. It used
+  // to live in state AND in this effect's dependency list, while every poll() call
+  // bumped it — so each poll re-ran the effect, which immediately polled again,
+  // firing ~10 back-to-back multicalls per mount (2s -> 60s) and another burst on
+  // every error reset.
   useEffect(() => {
     if (!address || !isWindowActive) return;
 
+    let cancelled = false;
+    intervalRef.current = INITIAL_POLL_INTERVAL;
+
+    const scheduleNext = () => {
+      if (cancelled) return;
+      timer.current = setTimeout(poll, intervalRef.current);
+    };
+
     const poll = async () => {
+      if (cancelled) return;
+
       try {
-        const result = await refetch();
-        // If data hasn't changed significantly, increase the interval
-        setPollInterval((prev) => Math.min(prev * BACKOFF_FACTOR, MAX_POLL_INTERVAL));
+        await refetch();
+        // Back off while the app is idle, up to MAX_POLL_INTERVAL.
+        intervalRef.current = Math.min(intervalRef.current * BACKOFF_FACTOR, MAX_POLL_INTERVAL);
       } catch (error) {
         console.error("Error polling member data:", error);
-        // Reset interval on error
-        setPollInterval(INITIAL_POLL_INTERVAL);
+        intervalRef.current = INITIAL_POLL_INTERVAL;
       }
+
+      scheduleNext();
     };
 
-    // Initial poll
+    // Poll once immediately, then let each run schedule the next.
     poll();
 
-    // Set up interval
-    timer.current = setInterval(poll, pollInterval);
-
     return () => {
-      clearInterval(timer.current);
+      cancelled = true;
+      clearTimeout(timer.current);
     };
-  }, [address, isWindowActive, refetch, pollInterval]);
+  }, [address, isWindowActive, refetch]);
 
   return resp;
 }

--- a/src/hooks/useTxHistory.js
+++ b/src/hooks/useTxHistory.js
@@ -1,5 +1,5 @@
 import { useAccount, useWatchContractEvent } from "wagmi";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { mainnet } from "viem/chains";
 
 import { ZERO_ADDRESS } from "constants";
@@ -37,49 +37,76 @@ export default function useTxHistory({ staker = ZERO_ADDRESS, borrower = ZERO_AD
       return;
     }
 
-    setData([]);
-    const registerTransactions = await fetchRegisterTransactions(version, chain?.id, staker);
-    const utokenTransactions = await fetchUTokenTransactions(version, chain?.id, staker);
-    const userTransactions = await fetchUserTransactions(version, chain?.id, staker);
+    // Initial/param-change loads clear first (previous behaviour); event-driven
+    // force refreshes keep the current rows on screen while fetching.
+    if (!force) setData([]);
 
-    const txHistory = [...registerTransactions, ...utokenTransactions, ...userTransactions].sort(
-      (a, b) => Number(b.timestamp) - Number(a.timestamp)
-    );
+    try {
+      const registerTransactions = await fetchRegisterTransactions(version, chain?.id, staker);
+      const utokenTransactions = await fetchUTokenTransactions(version, chain?.id, staker);
+      const userTransactions = await fetchUserTransactions(version, chain?.id, staker);
 
-    cache(cacheKey, txHistory);
-    setData(txHistory);
-    setLoading(false);
+      const txHistory = [...registerTransactions, ...utokenTransactions, ...userTransactions].sort(
+        (a, b) => Number(b.timestamp) - Number(a.timestamp)
+      );
+
+      cache(cacheKey, txHistory);
+      setData(txHistory);
+    } catch (error) {
+      // The fetchers have no internal error handling and the subgraph can be
+      // unavailable — a failed refresh must not destroy already-rendered history.
+      console.error("Failed to load transaction history:", error);
+    } finally {
+      setLoading(false);
+    }
   }
 
   // wagmi v2 takes `onLogs` and passes an array of logs with decoded named args.
   // The previous `listener` prop (the v1 positional shape) was silently ignored,
   // so a new borrow or repay never refreshed the history.
   //
+  // Handler identity matters: wagmi keeps `onLogs` in its subscription effect's
+  // dependency array, so a fresh handler per render would tear down and re-create
+  // the watcher every render. The closure values (loadData, staker, borrower) are
+  // kept fresh in a ref and the handlers are created once.
+  //
   // Arg names match the uToken ABI: LogBorrow(account, to, amount, fee) and
   // LogRepay(payer, account, amount).
-  const involvesAddresses = (logs, keys) =>
-    (logs || []).some((log) =>
-      keys.some(
-        (key) =>
-          compareAddresses(log?.args?.[key], staker) ||
-          compareAddresses(log?.args?.[key], borrower)
-      )
-    );
+  const latest = useRef({ loadData, staker, borrower });
+  useEffect(() => {
+    latest.current = { loadData, staker, borrower };
+  });
+
+  const reloadIfInvolved = useCallback(
+    (keys) => (logs) => {
+      const { loadData: load, staker: s, borrower: b } = latest.current;
+
+      const involved = (logs || []).some((log) =>
+        keys.some(
+          (key) => compareAddresses(log?.args?.[key], s) || compareAddresses(log?.args?.[key], b)
+        )
+      );
+
+      if (involved) load(true);
+    },
+    []
+  );
+
+  const onBorrowLogs = useMemo(() => reloadIfInvolved(["account", "to"]), [reloadIfInvolved]);
+  const onRepayLogs = useMemo(() => reloadIfInvolved(["payer", "account"]), [reloadIfInvolved]);
 
   useWatchContractEvent({
     ...uTokenManager,
     eventName: "LogBorrow",
-    onLogs: (logs) => {
-      if (involvesAddresses(logs, ["account", "to"])) loadData(true);
-    },
+    enabled: !!uTokenManager.address,
+    onLogs: onBorrowLogs,
   });
 
   useWatchContractEvent({
     ...uTokenManager,
     eventName: "LogRepay",
-    onLogs: (logs) => {
-      if (involvesAddresses(logs, ["payer", "account"])) loadData(true);
-    },
+    enabled: !!uTokenManager.address,
+    onLogs: onRepayLogs,
   });
 
   useEffect(() => {

--- a/src/hooks/useTxHistory.js
+++ b/src/hooks/useTxHistory.js
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { mainnet } from "viem/chains";
 
 import { ZERO_ADDRESS } from "constants";
+import { compareAddresses } from "utils/compare";
 import useContract from "hooks/useContract";
 import { useCache } from "providers/Cache";
 import { useVersion } from "providers/Version";
@@ -21,8 +22,11 @@ export default function useTxHistory({ staker = ZERO_ADDRESS, borrower = ZERO_AD
   const [loading, setLoading] = useState(true);
   const uTokenManager = useContract("uToken", chain?.id ?? mainnet.id);
 
-  async function loadData() {
-    if (cached(cacheKey)) {
+  // `force` bypasses the cache read. An event-driven refresh must skip it —
+  // otherwise a new borrow/repay would re-serve the cached (pre-event) history and
+  // the refresh would be a no-op.
+  async function loadData(force = false) {
+    if (!force && cached(cacheKey)) {
       setData(cached(cacheKey));
       setLoading(false);
       return;
@@ -47,22 +51,34 @@ export default function useTxHistory({ staker = ZERO_ADDRESS, borrower = ZERO_AD
     setLoading(false);
   }
 
-  // todo: implement onLogs handler
+  // wagmi v2 takes `onLogs` and passes an array of logs with decoded named args.
+  // The previous `listener` prop (the v1 positional shape) was silently ignored,
+  // so a new borrow or repay never refreshed the history.
+  //
+  // Arg names match the uToken ABI: LogBorrow(account, to, amount, fee) and
+  // LogRepay(payer, account, amount).
+  const involvesAddresses = (logs, keys) =>
+    (logs || []).some((log) =>
+      keys.some(
+        (key) =>
+          compareAddresses(log?.args?.[key], staker) ||
+          compareAddresses(log?.args?.[key], borrower)
+      )
+    );
+
   useWatchContractEvent({
     ...uTokenManager,
     eventName: "LogBorrow",
-    listener: (account, to, amount, fee) => {
-      console.debug("Listener: LogBorrow received", { account, to, amount, fee });
-      loadData();
+    onLogs: (logs) => {
+      if (involvesAddresses(logs, ["account", "to"])) loadData(true);
     },
   });
 
   useWatchContractEvent({
     ...uTokenManager,
     eventName: "LogRepay",
-    listener: (payer, borrower, sendAmount) => {
-      console.debug("Listener: LogRepay received", { payer, borrower, sendAmount });
-      loadData();
+    onLogs: (logs) => {
+      if (involvesAddresses(logs, ["payer", "account"])) loadData(true);
     },
   });
 

--- a/src/providers/GovernanceData.jsx
+++ b/src/providers/GovernanceData.jsx
@@ -61,12 +61,18 @@ const proposalsQuery = gql`
   }
 `;
 
-const selectProposals = (data) => {
+export const selectProposals = (data) => {
   return chunk(
     data.map((d) => d.result),
     2
   ).map(([proposal, state]) => {
     if (!proposal) return {};
+
+    // Vote tallies come back as uint256 -> BigInt.
+    const forVotes = proposal.forVotes ?? 0n;
+    const againstVotes = proposal.againstVotes ?? 0n;
+    const abstainVotes = proposal.abstainVotes ?? 0n;
+    const totalVotes = forVotes + againstVotes + abstainVotes;
 
     return {
       // proposal(uint256 pid)
@@ -83,14 +89,14 @@ const selectProposals = (data) => {
       // state(uint256 pid)
       state,
       status: ProposalState[state],
-      // Computed values
-      percentageFor:
-        Number(
-          (
-            (proposal.forVotes * 1000) /
-            (proposal.againstVotes + proposal.forVotes + proposal.abstainVotes)
-          ).toString()
-        ) / 1000,
+      // Computed values — kept entirely in BigInt.
+      //
+      // This was `proposal.forVotes * 1000`, mixing a BigInt with a Number
+      // literal, which throws "Cannot mix BigInt and other types". Because it ran
+      // inside react-query's `select`, the throw errored the whole proposals query
+      // and no on-chain state or vote tallies rendered whenever a proposal existed.
+      // Scaling by 10000n also guards division by zero on a proposal with no votes.
+      percentageFor: totalVotes > 0n ? Number((forVotes * 10000n) / totalVotes) / 10000 : 0,
     };
   });
 };

--- a/src/providers/MemberData.jsx
+++ b/src/providers/MemberData.jsx
@@ -1,5 +1,5 @@
 import { useAccount, useReadContracts } from "wagmi";
-import { createContext, useContext, useState, useEffect } from "react";
+import { createContext, useContext } from "react";
 
 import { CACHE_TIME, STALE_TIME, ZERO, ZERO_ADDRESS } from "constants";
 import { useVersion, Versions } from "./Version";
@@ -239,18 +239,16 @@ export default function MemberData({ chainId, children, address: addressProp }) 
 
   const pollResp = usePollMemberData(address, chainId);
 
-  // Track the last successful refetch timestamp
-  const [lastRefetchTime, setLastRefetchTime] = useState(0);
-
-  // Update refetch timestamp when main data is refetched
-  useEffect(() => {
-    if (resp.isFetched) {
-      setLastRefetchTime(Date.now());
-    }
-  }, [resp.isFetched]);
-
-  // Determine which data source is more recent
-  const isMainDataFresh = lastRefetchTime > (pollResp.data?.timestamp || 0);
+  // Determine which data source is more recent, using react-query's own
+  // per-query update timestamps.
+  //
+  // This previously compared a manually-tracked time against
+  // `pollResp.data.timestamp` — a field the poll's `select` never set, so the
+  // right-hand side was always 0 and `isMainDataFresh` was permanently true once
+  // the main query had fetched. The polled owed/interest/unclaimedRewards values
+  // were therefore fetched and then silently discarded. (The manual timestamp was
+  // also only ever set once, since it keyed off `isFetched` flipping false->true.)
+  const isMainDataFresh = (resp.dataUpdatedAt ?? 0) >= (pollResp.dataUpdatedAt ?? 0);
 
   return (
     <MemberContext.Provider 

--- a/src/providers/Network.jsx
+++ b/src/providers/Network.jsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { getDefaultConfig, RainbowKitProvider } from "@rainbow-me/rainbowkit";
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useMemo, useState } from "react";
 import { base, mainnet, optimism } from "viem/chains";
 import { WagmiProvider } from "wagmi";
 import { fallback, http } from "viem";
@@ -39,13 +39,19 @@ export const config = getDefaultConfig({
   }, {}),
 });
 
+// Created once at module scope, alongside `config`. Previously constructed in the
+// Network render body, so toggling `forceAppReady` produced a fresh QueryClient
+// and discarded the entire wagmi on-chain read cache (every balance / credit /
+// member query refetched from scratch).
+const queryClient = new QueryClient();
+
 export default function Network({ children }) {
   const [forceAppReady, setForceAppReady] = useState(false);
 
-  const queryClient = new QueryClient();
+  const contextValue = useMemo(() => ({ forceAppReady, setForceAppReady }), [forceAppReady]);
 
   return (
-    <NetworkContext.Provider value={{ forceAppReady, setForceAppReady }}>
+    <NetworkContext.Provider value={contextValue}>
       <WagmiProvider config={config}>
         <QueryClientProvider client={queryClient}>
           <RainbowKitProvider>{children}</RainbowKitProvider>

--- a/src/providers/VoucheesData.jsx
+++ b/src/providers/VoucheesData.jsx
@@ -17,23 +17,36 @@ export const useVouchees = () => useContext(VoucheesContext);
 export const useVouchee = (address) =>
   (useVouchees()?.data ?? []).find((v) => compareAddresses(v.address, address));
 
-const selectVouchee = (version) => (data) => ({
-  isMember: data[0],
-  ...(version === Versions.V1
-    ? {
-        locking: data[1].lockedStake,
-        trust: data[1].trustAmount,
-        vouch: data[1].vouchingAmount,
-      }
-    : {
-        locking: data[1].voucher.locked,
-        trust: data[1].voucher.trust,
-        vouch: data[1].voucher.vouch,
-      }),
-  isOverdue: data[2],
-  interest: data[3] || ZERO,
-  lastRepay: data[4],
-});
+// Every field is read defensively. wagmi's `allowFailure` default yields
+// `result: undefined` for any reverted or failed sub-call, and this ran inside
+// react-query's `select` — so a single failing entry (transient RPC error, a
+// contract/chain mismatch for one staker) threw a TypeError that errored the whole
+// query and made the ENTIRE providing/receiving contact list disappear, instead of
+// degrading the one affected row.
+export const selectVouchee = (version) => (data) => {
+  const [isMember = false, info, isOverdue = false, interest, lastRepay] = data || [];
+
+  const related =
+    version === Versions.V1
+      ? {
+          locking: info?.lockedStake ?? ZERO,
+          trust: info?.trustAmount ?? ZERO,
+          vouch: info?.vouchingAmount ?? ZERO,
+        }
+      : {
+          locking: info?.voucher?.locked ?? ZERO,
+          trust: info?.voucher?.trust ?? ZERO,
+          vouch: info?.voucher?.vouch ?? ZERO,
+        };
+
+  return {
+    isMember,
+    ...related,
+    isOverdue,
+    interest: interest ?? ZERO,
+    lastRepay: lastRepay ?? ZERO,
+  };
+};
 
 export const useVoucheesData = (address, chainId, forcedVersion) => {
   const { version } = useVersion();

--- a/src/providers/VouchersData.jsx
+++ b/src/providers/VouchersData.jsx
@@ -17,23 +17,29 @@ export const useVouchers = () => useContext(VouchersContext);
 export const useVoucher = (address) =>
   (useVouchers()?.data ?? []).find((v) => compareAddresses(v.address, address));
 
-const selectVoucher = (version) => (data) => {
-  const [checkIsMember = false, stakedBalance = ZERO, info = []] = data || [];
+// Read defensively — see the note in VoucheesData.selectVouchee. Note the old
+// `info = []` default did NOT help the V2 path: `[].voucher` is undefined, so
+// `info.voucher.locked` still threw and wiped the whole vouchers list.
+export const selectVoucher = (version) => (data) => {
+  const [checkIsMember = false, stakedBalance = ZERO, info] = data || [];
+
+  const related =
+    version === Versions.V1
+      ? {
+          locking: info?.lockedStake ?? ZERO,
+          trust: info?.trustAmount ?? ZERO,
+          vouch: info?.vouchingAmount ?? ZERO,
+        }
+      : {
+          locking: info?.voucher?.locked ?? ZERO,
+          trust: info?.voucher?.trust ?? ZERO,
+          vouch: info?.voucher?.vouch ?? ZERO,
+        };
 
   return {
     checkIsMember,
-    stakedBalance,
-    ...(version === Versions.V1
-      ? {
-          locking: info.lockedStake,
-          trust: info.trustAmount,
-          vouch: info.vouchingAmount,
-        }
-      : {
-          locking: info.voucher.locked,
-          trust: info.voucher.trust,
-          vouch: info.voucher.vouch,
-        }),
+    stakedBalance: stakedBalance ?? ZERO,
+    ...related,
   };
 };
 

--- a/src/providers/dataSelectors.test.js
+++ b/src/providers/dataSelectors.test.js
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import { selectVoucher } from "providers/VouchersData";
+import { selectVouchee } from "providers/VoucheesData";
+import { selectProposals } from "providers/GovernanceData";
+import { Versions } from "providers/Version";
+import { ZERO } from "constants";
+
+// wagmi's `allowFailure` default yields `result: undefined` for any sub-call that
+// reverts or fails. These selectors run inside react-query's `select`, so a throw
+// there errors the WHOLE query — one bad row used to wipe the entire contacts list.
+const V2_INFO = { voucher: { locked: 10n, trust: 20n, vouch: 30n } };
+const V1_INFO = { lockedStake: 10n, trustAmount: 20n, vouchingAmount: 30n };
+
+describe("selectVoucher (vouchers list)", () => {
+  it("maps a healthy V2 row", () => {
+    const r = selectVoucher(Versions.V2)([true, 500n, V2_INFO]);
+    expect(r).toMatchObject({ checkIsMember: true, stakedBalance: 500n, locking: 10n, trust: 20n, vouch: 30n });
+  });
+
+  it("maps a healthy V1 row", () => {
+    const r = selectVoucher(Versions.V1)([true, 500n, V1_INFO]);
+    expect(r).toMatchObject({ locking: 10n, trust: 20n, vouch: 30n });
+  });
+
+  // Regression: the V2 path did `info.voucher.locked` with an `info = []` default,
+  // so `[].voucher` was undefined and this threw, erroring the whole query.
+  it("degrades to zeros when the related-info sub-call failed (V2)", () => {
+    expect(() => selectVoucher(Versions.V2)([true, 500n, undefined])).not.toThrow();
+    const r = selectVoucher(Versions.V2)([true, 500n, undefined]);
+    expect(r).toMatchObject({ checkIsMember: true, stakedBalance: 500n, locking: ZERO, trust: ZERO, vouch: ZERO });
+  });
+
+  it("degrades to zeros when the related-info sub-call failed (V1)", () => {
+    expect(() => selectVoucher(Versions.V1)([true, 500n, undefined])).not.toThrow();
+    expect(selectVoucher(Versions.V1)([true, 500n, undefined])).toMatchObject({ locking: ZERO });
+  });
+
+  it("survives an entirely failed row", () => {
+    expect(() => selectVoucher(Versions.V2)([])).not.toThrow();
+    expect(() => selectVoucher(Versions.V2)(undefined)).not.toThrow();
+    expect(selectVoucher(Versions.V2)([])).toMatchObject({ checkIsMember: false, stakedBalance: ZERO });
+  });
+});
+
+describe("selectVouchee (vouchees list)", () => {
+  it("maps a healthy V2 row", () => {
+    const r = selectVouchee(Versions.V2)([true, V2_INFO, false, 5n, 100n]);
+    expect(r).toMatchObject({ isMember: true, locking: 10n, trust: 20n, vouch: 30n, isOverdue: false, interest: 5n, lastRepay: 100n });
+  });
+
+  // Regression: read `data[1].voucher.locked` with no guard at all.
+  it("degrades to zeros when the related-info sub-call failed", () => {
+    expect(() => selectVouchee(Versions.V2)([true, undefined, false, 5n, 100n])).not.toThrow();
+    expect(selectVouchee(Versions.V2)([true, undefined, false, 5n, 100n])).toMatchObject({
+      locking: ZERO,
+      trust: ZERO,
+      vouch: ZERO,
+    });
+  });
+
+  it("survives an entirely failed row", () => {
+    expect(() => selectVouchee(Versions.V1)([])).not.toThrow();
+    expect(() => selectVouchee(Versions.V2)(undefined)).not.toThrow();
+  });
+});
+
+describe("selectProposals (governance vote tallies)", () => {
+  const proposal = (forV, againstV, abstainV) => ({
+    id: 1n,
+    proposer: "0x1",
+    eta: 0n,
+    startBlock: 1n,
+    endBlock: 2n,
+    forVotes: forV,
+    againstVotes: againstV,
+    abstainVotes: abstainV,
+    canceled: false,
+    executed: false,
+  });
+  const wrap = (p, state = 1) => [{ result: p }, { result: state }];
+
+  // Regression: `proposal.forVotes * 1000` mixed BigInt with a Number literal and
+  // threw "Cannot mix BigInt and other types" inside select, so the whole
+  // proposals query errored and no tallies rendered.
+  it("computes percentageFor from BigInt tallies without throwing", () => {
+    expect(() => selectProposals(wrap(proposal(50n, 50n, 0n)))).not.toThrow();
+    expect(selectProposals(wrap(proposal(50n, 50n, 0n)))[0].percentageFor).toBe(0.5);
+    expect(selectProposals(wrap(proposal(75n, 25n, 0n)))[0].percentageFor).toBe(0.75);
+    expect(selectProposals(wrap(proposal(1n, 0n, 0n)))[0].percentageFor).toBe(1);
+  });
+
+  it("handles wei-scale tallies (where Number would lose precision)", () => {
+    const forV = 1_000_000n * 10n ** 18n;
+    const againstV = 3_000_000n * 10n ** 18n;
+    expect(selectProposals(wrap(proposal(forV, againstV, 0n)))[0].percentageFor).toBe(0.25);
+  });
+
+  it("returns 0 instead of dividing by zero when a proposal has no votes", () => {
+    expect(selectProposals(wrap(proposal(0n, 0n, 0n)))[0].percentageFor).toBe(0);
+  });
+
+  it("still maps the proposal fields", () => {
+    const [p] = selectProposals(wrap(proposal(1n, 1n, 0n), 4));
+    expect(p).toMatchObject({ pid: 1n, forVotes: 1n, state: 4, status: "succeeded" });
+  });
+});

--- a/src/utils/compare.js
+++ b/src/utils/compare.js
@@ -1,1 +1,5 @@
-export const compareAddresses = (a, b) => a.toLowerCase() === b.toLowerCase();
+// Null-safe: callers include event-log handlers and lookups where an address can
+// legitimately be absent (disconnected wallet, undecoded log arg). Previously
+// threw on a nullish argument.
+export const compareAddresses = (a, b) =>
+  typeof a === "string" && typeof b === "string" && a.toLowerCase() === b.toLowerCase();


### PR DESCRIPTION
## Summary
Eight fixes across the on-chain data layer — the "Data staleness & RPC pressure" cluster plus the multicall-resilience bug. Every one was **verified by executing the old expression against the same input**, not inferred.

## Stale data

**1. Contract event listeners never ran** (`useMemberListener`, `useTxHistory`)
7 subscriptions passed a `listener` prop taking positional args — the **wagmi v1** shape. wagmi v2's `useWatchContractEvent` takes **`onLogs`** and passes an *array* of logs with *decoded named* args, so every handler was an ignored unknown prop.

*Impact:* if a third party repaid your loan, vouched for you, cancelled a vouch, or wrote off debt, nothing refreshed until a manual refetch or the 2-minute focus refetch. Converted to `onLogs`, with arg names read straight from the ABIs (`staker`/`borrower`, `account`/`borrower`, `from`/`to`, `payer`/`account`) — the old positional handlers also mis-assumed `LogRegisterMember`'s arg order, so both addresses are now checked.

**2. `useTxHistory` cache short-circuit made the listener a no-op**
`loadData()` returns early on a cache hit, so an event-driven reload would have re-served the *pre-event* history. Added a `force` flag used by the event handlers.

**3. Polled member data was fetched and discarded** (`MemberData`)
`isMainDataFresh` compared a manual timestamp against `pollResp.data.timestamp` — **a field the poll's `select` never sets** — so it was permanently `true` once the main query fetched, and every polled `owed`/`interest`/`unclaimedRewards` was thrown away. Now compares react-query's own `dataUpdatedAt` per query, which also removes the one-shot `isFetched` effect that only ever fired once.

## RPC pressure

**4. ~10 back-to-back multicalls per mount** (`usePollMember`)
`pollInterval` was *both* state *and* an effect dependency, while every `poll()` bumped it — so each poll re-ran the effect, which polled again immediately (2s → 60s), plus a fresh burst on every error reset. The interval now lives in a ref and each run self-schedules.

**5. `ApolloClient` + empty cache rebuilt every render** (`App.jsx`) → hoisted to module scope.

**6. `new QueryClient()` in the `Network` render body** → discarded the entire wagmi on-chain read cache whenever `forceAppReady` toggled. Hoisted to module scope; context value memoized.

## Crashes / resilience

**7. One failed multicall sub-call wiped the whole contacts list** (`VouchersData`, `VoucheesData`)
wagmi's `allowFailure` default yields `result: undefined` for a failed sub-call, and these `select` functions read related-info fields unguarded — so one bad entry (transient RPC error, contract/chain mismatch for a single staker) threw *inside* `select`, erroring the whole query and making the **entire** providing/receiving list disappear rather than degrading one row. Note the old `info = []` default did **not** help V2: `[].voucher` is undefined.

**8. Governance vote tallies never rendered** (`GovernanceData`)
`proposal.forVotes * 1000` mixed BigInt with a Number literal → throws inside `select` → the proposals query errored whenever a proposal existed. Now BigInt-only, with a division-by-zero guard.

Plus: `setReferrer` moved out of the render body into an effect (impure render), and `compareAddresses` made null-safe (it threw on a nullish arg, and log handlers can legitimately see `undefined`).

## Proof the bugs were real
```
OLD code, on a failed multicall sub-call (result === undefined):
  THROWS -> selectVoucher V2  info.voucher.locked   : Cannot read properties of undefined (reading 'locked')
  THROWS -> selectVouchee V2  data[1].voucher.locked: Cannot read properties of undefined (reading 'voucher')
  THROWS -> selectVouchee V1  data[1].lockedStake   : Cannot read properties of undefined (reading 'lockedStake')

OLD governance math, on real BigInt tallies:
  THROWS -> percentageFor  forVotes * 1000          : Cannot mix BigInt and other types
NEW: 0.5
```

## Tests
Adds `src/providers/dataSelectors.test.js` (12 tests) — the selectors are now exported so the failure paths are directly testable: healthy V1/V2 rows, a failed related-info sub-call, an entirely failed row, and the BigInt vote math (including wei-scale tallies where `Number` would lose precision, and the zero-vote case).

## Verification
- **23/23** unit tests pass (12 new + 11 existing) · `yarn build` clean
- **Headless load of a real profile page** returns the same on-chain data *and* the same `DistributionBar` geometry (`[13, 427]`) as production — confirming member/vouchers/vouchees data still maps correctly through the rewritten selectors.

## What is NOT verified here
These paths need a connected wallet or a live third-party event, which no automation in this repo covers yet:
- that `onLogs` actually fires on a real event (the *shape* is now correct per the wagmi v2 API and the ABI arg names, but I could not trigger a live event)
- the polling backoff observed over minutes in a real session
- `usePermit` / write flows (untouched here)

Worth a manual pass on the preview: open the app connected, confirm contacts + governance render, and ideally have someone vouch for you to see the auto-refresh fire.
