### PR TITLE
fix(rpc): Optimism/Arbitrum fallbacks — exhausted Alchemy quota blanks chains without one

### DIFF
--- a/src/providers/Network.jsx
+++ b/src/providers/Network.jsx
@@ -15,11 +15,19 @@ const NetworkContext = createContext({});
 
 export const useAppNetwork = () => useContext(NetworkContext);
 
-// Public fallback RPCs used when the primary (Alchemy) endpoint fails — notably
-// keeps mainnet ENS resolution working even if the Alchemy app lacks Ethereum Mainnet.
+// Public fallback RPCs used when the primary (Alchemy) endpoint fails — e.g.
+// when the Alchemy app's monthly capacity is exhausted (observed in production:
+// every network 429s with "Monthly capacity limit exceeded"), or a network is
+// missing from the Alchemy app. Every configured chain needs an entry here:
+// Optimism had none, so exhausted Alchemy quota blanked all Optimism data while
+// Base and mainnet kept working through their fallbacks. All endpoints below are
+// CORS-open (verified) and only serve tip reads in the browser, so full-history
+// capability is not required.
 const FALLBACK_RPCS = {
   [base.id]: "https://base-rpc.publicnode.com",
   [mainnet.id]: "https://ethereum-rpc.publicnode.com",
+  [optimism.id]: "https://mainnet.optimism.io",
+  [arbitrum.id]: "https://arb1.arbitrum.io/rpc",
 };
 
 export const config = getDefaultConfig({


### PR DESCRIPTION
## Summary
Production's Alchemy key is over its monthly capacity — **every network returns `429 Monthly capacity limit exceeded`** (verified directly with the `app.union.finance` origin header). Chains with a public fallback (#464: Base, mainnet) fail over and keep working; **Optimism has no fallback, so all Optimism on-chain data renders empty** — the reported `/protocol` blank. Arbitrum was likewise uncovered.

## Fix
Add the two missing entries to `FALLBACK_RPCS`:
- optimism → `https://mainnet.optimism.io`
- arbitrum → `https://arb1.arbitrum.io/rpc`

Both verified: answer `eth_blockNumber`, CORS-open (`access-control-allow-origin: *`). Browser reads are tip-only, so pruning is irrelevant here.

## Verification
- 32/32 unit tests pass, build clean
- Direct probes of all four Alchemy networks with the app origin → all 429 (root cause confirmed)
- Both fallback endpoints probed with browser-style Origin header

## ⚠️ Still needs dashboard action
The quota itself: upgrade the Alchemy plan, wait for the monthly reset, or rotate to a key with capacity — this PR only makes exhaustion degrade gracefully. Also note **#468 (unmerged) removes the app's polling storm**, which is a meaningful chunk of the RPC burn.