### PR TITLE
feat: copyable addresses in leaderboard and contacts tables

### DIFF
--- a/src/components/contacts/ContactsTable/ProvidingTableRow.jsx
+++ b/src/components/contacts/ContactsTable/ProvidingTableRow.jsx
@@ -1,8 +1,7 @@
 import "./ProvidingTableRow.scss";
 
 import { Box, TableCell, TableRow, Text } from "@unioncredit/ui";
-import { Avatar, PrimaryLabel, StatusBadge } from "components/shared";
-import { truncateAddress } from "utils/truncateAddress";
+import { Avatar, CopyableAddress, PrimaryLabel, StatusBadge } from "components/shared";
 import { ContactsType, ZERO } from "constants";
 import format from "utils/format";
 import cn from "classnames";
@@ -125,9 +124,7 @@ export function ProvidingTableRow({ data, active, setContact, providing, receivi
             <Icon className="ProvidingTableRow__icon" />
           </Box>
 
-          <Text size="small" grey={500} m={0} weight="medium">
-            {truncateAddress(address)}
-          </Text>
+          <CopyableAddress address={address} />
         </Box>
       </TableCell>
 

--- a/src/components/contacts/ContactsTable/ReceivingTableRow.jsx
+++ b/src/components/contacts/ContactsTable/ReceivingTableRow.jsx
@@ -1,8 +1,7 @@
 import "./ProvidingTableRow.scss";
 
 import { Box, TableCell, TableRow, Text } from "@unioncredit/ui";
-import { Avatar, PrimaryLabel } from "components/shared";
-import { truncateAddress } from "utils/truncateAddress";
+import { Avatar, CopyableAddress, PrimaryLabel } from "components/shared";
 import { ZERO } from "constants";
 import format from "utils/format";
 import { DimmableTableCell } from "components/contacts/ContactsTable";
@@ -113,9 +112,7 @@ export function ReceivingTableRow({ data, active, setContact, providing, receivi
             <Icon className="ProvidingTableRow__icon" />
           </Box>
 
-          <Text size="small" grey={500} m={0} weight="medium">
-            {truncateAddress(address)}
-          </Text>
+          <CopyableAddress address={address} />
         </Box>
       </TableCell>
 

--- a/src/components/dao/LeaderboardTableRow.jsx
+++ b/src/components/dao/LeaderboardTableRow.jsx
@@ -1,6 +1,5 @@
 import { Box, TableCell, TableRow, Text } from "@unioncredit/ui";
-import { Avatar, PrimaryLabel } from "components/shared";
-import { truncateAddress } from "utils/truncateAddress";
+import { Avatar, CopyableAddress, PrimaryLabel } from "components/shared";
 import { isAddress } from "viem";
 
 export function LeaderboardTableRow({ num, data }) {
@@ -21,9 +20,7 @@ export function LeaderboardTableRow({ num, data }) {
           <Text grey={800} m={0} size="medium" weight="medium">
             <PrimaryLabel address={address} />
           </Text>
-          <Text grey={500} m={0} size="small" weight="medium">
-            {truncateAddress(address)}
-          </Text>
+          <CopyableAddress address={address} />
         </Box>
       </TableCell>
 

--- a/src/components/shared/CopyableAddress.jsx
+++ b/src/components/shared/CopyableAddress.jsx
@@ -1,0 +1,30 @@
+import { Text } from "@unioncredit/ui";
+
+import useCopyToClipboard from "hooks/useCopyToClipboard";
+import { truncateAddress } from "utils/truncateAddress";
+
+// Truncated address text that copies the full address on click, with the same
+// transient "Copied!" feedback as the wallet & activity modal. Clicks stop
+// propagating so copying never triggers a parent row's own click behaviour
+// (e.g. opening a contact modal).
+export function CopyableAddress({ address, ...props }) {
+  const [copied, copy] = useCopyToClipboard();
+
+  return (
+    <Text
+      m={0}
+      size="small"
+      grey={500}
+      weight="medium"
+      title="Copy address"
+      style={{ cursor: "pointer" }}
+      onClick={(event) => {
+        event.stopPropagation();
+        copy(address);
+      }}
+      {...props}
+    >
+      {copied ? "Copied!" : truncateAddress(address)}
+    </Text>
+  );
+}

--- a/src/components/shared/CopyableAddress.test.jsx
+++ b/src/components/shared/CopyableAddress.test.jsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CopyableAddress } from "components/shared/CopyableAddress";
+
+const ADDRESS = "0x57bd0eEcE6a0B5b8f2fc0E2d0E5aA51e34E44EFb";
+
+describe("CopyableAddress", () => {
+  let writeText;
+
+  beforeEach(() => {
+    writeText = vi.fn().mockResolvedValue();
+    Object.assign(navigator, { clipboard: { writeText } });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the truncated address", () => {
+    render(<CopyableAddress address={ADDRESS} />);
+    expect(screen.getByText("0x57bd...4EFb")).toBeInTheDocument();
+  });
+
+  it("copies the FULL address on click and shows the Copied! feedback", async () => {
+    render(<CopyableAddress address={ADDRESS} />);
+
+    fireEvent.click(screen.getByText("0x57bd...4EFb"));
+
+    expect(writeText).toHaveBeenCalledWith(ADDRESS);
+    expect(await screen.findByText("Copied!")).toBeInTheDocument();
+  });
+
+  it("does not trigger a parent's click handler (rows navigate/open modals)", () => {
+    const parentClick = vi.fn();
+    render(
+      <div onClick={parentClick}>
+        <CopyableAddress address={ADDRESS} />
+      </div>
+    );
+
+    fireEvent.click(screen.getByText("0x57bd...4EFb"));
+
+    expect(parentClick).not.toHaveBeenCalled();
+    expect(writeText).toHaveBeenCalledWith(ADDRESS);
+  });
+});

--- a/src/components/shared/index.js
+++ b/src/components/shared/index.js
@@ -6,6 +6,7 @@ export * from "./AddressSummary";
 export * from "./Approval";
 export * from "./Avatar";
 export * from "./ConnectButton";
+export * from "./CopyableAddress";
 export * from "./EditLabel";
 export * from "./Header";
 export * from "./HeaderMobileMenu";


### PR DESCRIPTION
## Summary
The truncated address under each account name in the **leaderboard tables** (all boards, incl. delegates) and the **contacts tables** (providing/receiving) is now click-to-copy, with the same transient **"Copied!"** feedback as the wallet & activity modal.

## Implementation
- New shared `CopyableAddress` component reusing the existing `useCopyToClipboard` hook (2s auto-reset) and `truncateAddress` formatting — visually identical to the current text, plus `cursor: pointer` and a "Copy address" tooltip
- `stopPropagation` on the copy click so it never triggers the row's own click behaviour (contact rows open the manage-contact modal)
- Wired into `LeaderboardTableRow`, `ProvidingTableRow`, `ReceivingTableRow`

## Verification
- **14/14 unit tests** (3 new: renders truncated form, copies the full address + shows feedback, does not propagate to parent click handlers)
- Build clean