### PR TITLE
fix(lint): repair eslint config, clear all 10 errors, restore lint to CI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "env": {
         "browser": true,
         "es2021": true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,9 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --frozen-lockfile
+      - run: yarn lint
       - run: yarn test
       - run: yarn build
-      # NOTE: `yarn lint` intentionally omitted — the eslint config is currently
-      # broken (empty package.json eslintConfig + an unresolved .eslintrc.json).
-      # Wire it back in once eslint is set up properly (separate task).
 
   integration:
     name: On-chain integration (Base fork)

--- a/package.json
+++ b/package.json
@@ -58,10 +58,7 @@
     "test:watch": "vitest",
     "test:integration": "vitest run --config vitest.integration.config.js",
     "format": "prettier --write \"src/**/*.{js,scss,json,jsx}\"",
-    "lint": "eslint --ext .js,.jsx ./src"
-  },
-  "eslintConfig": {
-    "extends": []
+    "lint": "eslint --ext .js,.jsx ./src --max-warnings 40"
   },
   "browserslist": {
     "production": [

--- a/src/components/profile/ProfileGovernanceStats.jsx
+++ b/src/components/profile/ProfileGovernanceStats.jsx
@@ -8,12 +8,21 @@ import { useMemberData } from "providers/MemberData";
 import { mainnet } from "wagmi/chains";
 import { Versions } from "providers/Version";
 import { useVoteParticipation } from "hooks/useVoteParticipation";
+import { useGovernanceStats } from "hooks/useGovernanceStats";
 
 export default function ProfileGovernanceStats({ address }) {
   const { data: member = {} } = useMemberData(address, mainnet.id, Versions.V1);
+  const { data: governance = {} } = useGovernanceStats({ address });
   const { voteCount, proposalCount, percentage } = useVoteParticipation(address);
 
   const { votes = ZERO } = member;
+  const { mainnetVotes = ZERO, mainnetBalance = ZERO } = governance;
+
+  // Power delegated in from other addresses, mirroring MyGovernanceStats. This
+  // read used to reference an undefined `votesDelegatedm` — a typo that would
+  // throw on first render (unreached today: ProfileSidebar, its only consumer,
+  // is not itself imported anywhere).
+  const votesDelegated = mainnetVotes - mainnetBalance;
 
   return (
     <Box className="ProfileGovernanceStats" direction="vertical">
@@ -46,7 +55,7 @@ export default function ProfileGovernanceStats({ address }) {
           },
           {
             label: "Delegated Power",
-            value: `${format(votesDelegatedm, "UNION")} Votes`,
+            value: `${format(votesDelegated, "UNION")} Votes`,
           },
           {
             label: "Vote Participation",

--- a/src/components/register/StakeStep.jsx
+++ b/src/components/register/StakeStep.jsx
@@ -32,7 +32,7 @@ export default function StakeStep({ complete, onSkipStep }) {
   const { chain } = useAccount();
   const { token, wad } = useToken();
 
-  const { data: member, refetch: refetchMember } = useMember();
+  const { data: member } = useMember();
   const { data: protocol } = useProtocol();
 
   const {
@@ -43,7 +43,6 @@ export default function StakeStep({ complete, onSkipStep }) {
     inflationPerSecond = ZERO,
     inflationPerBlock = ZERO,
     unclaimedRewards = ZERO,
-    newMemberFee = ZERO,
   } = { ...protocol, ...member };
 
   const inflationPerUnit = inflationPerSecond || inflationPerBlock;

--- a/src/components/shared/BuildInfo.jsx
+++ b/src/components/shared/BuildInfo.jsx
@@ -20,12 +20,11 @@ export function BuildInfo() {
       </Text>
       <Text size="small" grey={300} align="center">
         <a
-          /* eslint-disable-next-line no-undef */
           target="_blank"
           rel="noreferrer"
           href="https://github.com/unioncredit/union-interface/issues/new"
         >
-          Report an issue ->
+          Report an issue -&gt;
         </a>
       </Text>
     </Box>

--- a/src/components/shared/FooterLinks.jsx
+++ b/src/components/shared/FooterLinks.jsx
@@ -33,12 +33,11 @@ export function FooterLinks() {
         </Text>
         <Text size="small" grey={300} align="center">
           <a
-            /* eslint-disable-next-line no-undef */
             target="_blank"
             rel="noreferrer"
             href="https://github.com/unioncredit/union-interface/issues/new"
           >
-            Report an issue ->
+            Report an issue -&gt;
           </a>
         </Text>
       </Box>

--- a/src/components/shared/ProfileSearchInput.jsx
+++ b/src/components/shared/ProfileSearchInput.jsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import { SearchIcon } from "@unioncredit/ui";
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useAccount } from "wagmi";
 import cn from "classnames";
 

--- a/src/hooks/useNetworks.js
+++ b/src/hooks/useNetworks.js
@@ -4,8 +4,14 @@ import { useMemo } from "react";
 
 export default function useNetworks(all = false, forceVersion = null) {
   const { version } = useVersion();
-  if (all) {
-    return useMemo(() => [...allNetworks[Versions.V1], ...allNetworks[Versions.V2]], []);
-  }
-  return useMemo(() => allNetworks[forceVersion ?? version], [forceVersion, version]);
+  // Both branches share one unconditional useMemo: calling a hook inside
+  // `if (all)` changed the hook order whenever `all` changed, which React
+  // forbids (and would throw once any caller passed a dynamic value).
+  return useMemo(
+    () =>
+      all
+        ? [...allNetworks[Versions.V1], ...allNetworks[Versions.V2]]
+        : allNetworks[forceVersion ?? version],
+    [all, forceVersion, version]
+  );
 }

--- a/src/hooks/useUser.js
+++ b/src/hooks/useUser.js
@@ -4,7 +4,6 @@ import { useEnsAvatar, useEnsName } from "wagmi";
 import { normalize } from "viem/ens";
 
 import { useNeynarUser } from "hooks/useNeynarUser";
-import { getNeynarAddress } from "utils/neynar";
 import { mainnet } from "viem/chains";
 import { truncateAddress } from "../utils/truncateAddress";
 

--- a/src/pages/Leaderboard.jsx
+++ b/src/pages/Leaderboard.jsx
@@ -96,7 +96,7 @@ export const BOARDS = {
 };
 
 export default function LeaderboardPage({ board }) {
-  const [copied, copy] = useCopyToClipboard();
+  const [copied] = useCopyToClipboard();
 
   const { open } = useModals();
 


### PR DESCRIPTION
`yarn lint` never actually ran. `.eslintrc.json` was missing `"root": true`, so eslint cascaded **past the project root**, picked up an ancestor config, and failed resolving `eslint-plugin-react` from that directory — exiting 2 before linting a single file. Everything below was hidden behind that.

## Real bugs found once it ran
- **`ProfileGovernanceStats` referenced an undefined `votesDelegatedm`** — a typo that throws `ReferenceError` the first time the component renders. It's unreached today only because its sole consumer, `ProfileSidebar`, isn't imported anywhere (unwired feature). Now computes delegated power the same way `MyGovernanceStats` does.
- **`useNetworks` called `useMemo` inside `if (all)`** — hook order changed with the argument (`rules-of-hooks`). Today every call site passes the default, so it's latent; one dynamic caller away from a React crash. Both branches now share a single unconditional `useMemo`.
- **`BuildInfo` / `FooterLinks` didn't parse at all** — a bare `>` in JSX text (`Report an issue ->`) is rejected by espree, so those files were silently skipped by every lint run. Escaped as `-&gt;`; compiles to the identical string (checked in the built bundle **and** rendered in-browser on `/protocol` and `/profile`).
- Five unused bindings removed: `useNavigate`, `getNeynarAddress`, `refetchMember`, `newMemberFee`, `copy`.

## Housekeeping
- Dropped the dead CRA `eslintConfig: { extends: [] }` stub from package.json (shadowed by `.eslintrc.json`; the CI note called it out).
- `--max-warnings 40` pins the 40 pre-existing `react-hooks/exhaustive-deps` warnings as a ceiling, so new ones fail CI instead of accumulating. Verified: adding one extra warning exits non-zero.
- **`yarn lint` restored to the CI unit job** (the note asking for this is removed).

Deliberately not touched: the 40 exhaustive-deps warnings. Each needs a per-hook correctness judgement, and several guard live subscriptions — a separate pass, not a mechanical sweep.

## Verification
- `yarn lint`: **0 errors**, 40 warnings, exit 0 ✅
- 35/35 unit + 4/4 Anvil Base-fork integration ✅
- `vite build` clean; headless render of `/`, `/protocol`, `/profile` — no new console errors ✅