### PR TITLE
feat: surface frozen stake from overdue contacts on the credit tabs

### DIFF
--- a/src/components/credit/FrozenStakeAlert.jsx
+++ b/src/components/credit/FrozenStakeAlert.jsx
@@ -1,11 +1,11 @@
 import "./FrozenStakeAlert.scss";
 
-import { Box, Button, Card, Text, WarningIcon } from "@unioncredit/ui";
+import { Box, Button, Card, CloseIcon, Text, WarningIcon } from "@unioncredit/ui";
 import { Link } from "react-router-dom";
 
 import format from "utils/format";
 import { useToken } from "hooks/useToken";
-import { useFrozenStake } from "hooks/useFrozenStake";
+import { useFrozenStakeAlert } from "hooks/useFrozenStakeAlert";
 import useResponsive from "hooks/useResponsive";
 import { AddressesAvatarBadgeRow } from "components/shared";
 
@@ -21,9 +21,9 @@ import { AddressesAvatarBadgeRow } from "components/shared";
 export function FrozenStakeAlert() {
   const { token } = useToken();
   const { isMobile } = useResponsive();
-  const { count, frozen, overdueVouchees, hasFrozenStake } = useFrozenStake();
+  const { count, frozen, overdueVouchees, visible, dismiss } = useFrozenStakeAlert();
 
-  if (!hasFrozenStake) return null;
+  if (!visible) return null;
 
   return (
     <Card mb="24px" className="FrozenStakeAlert">
@@ -65,6 +65,19 @@ export function FrozenStakeAlert() {
               color="secondary"
               variant="light"
               label="View contacts"
+            />
+
+            <Button
+              p="0 !important"
+              ml="4px"
+              size="small"
+              color="secondary"
+              variant="light"
+              icon={CloseIcon}
+              onClick={dismiss}
+              aria-label="Dismiss"
+              className="FrozenStakeAlert__dismiss"
+              iconProps={{ style: { minWidth: "24px", minHeight: "24px" } }}
             />
           </Box>
         </Box>

--- a/src/components/credit/FrozenStakeAlert.jsx
+++ b/src/components/credit/FrozenStakeAlert.jsx
@@ -1,0 +1,74 @@
+import "./FrozenStakeAlert.scss";
+
+import { Box, Button, Card, Text, WarningIcon } from "@unioncredit/ui";
+import { Link } from "react-router-dom";
+
+import format from "utils/format";
+import { useToken } from "hooks/useToken";
+import { useFrozenStake } from "hooks/useFrozenStake";
+import useResponsive from "hooks/useResponsive";
+import { AddressesAvatarBadgeRow } from "components/shared";
+
+/**
+ * Staker-side delinquency, surfaced where the member already is.
+ *
+ * The overdue detail has always existed on the Stake tab (StakeStats' Frozen
+ * block) and in the contacts table, but a member who backs an overdue borrower
+ * lands on Borrow and sees only their own credit — so frozen capital went
+ * unnoticed until they happened to navigate. This renders across the credit
+ * tabs whenever the member actually has stake frozen.
+ */
+export function FrozenStakeAlert() {
+  const { token } = useToken();
+  const { isMobile } = useResponsive();
+  const { count, frozen, overdueVouchees, hasFrozenStake } = useFrozenStake();
+
+  if (!hasFrozenStake) return null;
+
+  return (
+    <Card mb="24px" className="FrozenStakeAlert">
+      <Card.Body>
+        {/* Box sets flex-direction as a prop, so the mobile stack has to be a
+            prop too — a CSS media query loses to it (as CreditStats does). */}
+        <Box
+          direction={isMobile ? "vertical" : "horizontal"}
+          align={isMobile ? "flex-start" : "center"}
+          justify="space-between"
+          className="FrozenStakeAlert__content"
+        >
+          <Box align="center" className="FrozenStakeAlert__summary">
+            <WarningIcon className="FrozenStakeAlert__icon" width="24px" />
+
+            <Box direction="vertical">
+              <Text m={0} size="medium" weight="medium" grey={800}>
+                {format(frozen, token)} {token} of your stake is frozen
+              </Text>
+              <Text m="2px 0 0" size="small" grey={500}>
+                {count === 1
+                  ? "A contact you back is overdue on their loan"
+                  : `${count} contacts you back are overdue on their loans`}
+              </Text>
+            </Box>
+          </Box>
+
+          <Box align="center" className="FrozenStakeAlert__action">
+            <AddressesAvatarBadgeRow
+              mr="12px"
+              className="FrozenStakeAlert__avatars"
+              addresses={overdueVouchees.map((v) => v.address)}
+            />
+
+            <Button
+              as={Link}
+              to="/contacts/providing?filters=overdue"
+              size="small"
+              color="secondary"
+              variant="light"
+              label="View contacts"
+            />
+          </Box>
+        </Box>
+      </Card.Body>
+    </Card>
+  );
+}

--- a/src/components/credit/FrozenStakeAlert.scss
+++ b/src/components/credit/FrozenStakeAlert.scss
@@ -1,0 +1,29 @@
+@import "@unioncredit/ui/src/variables";
+
+.FrozenStakeAlert {
+  border-color: $amber500;
+  background: $amber50;
+
+  &__icon {
+    margin-right: 12px;
+    flex-shrink: 0;
+
+    path {
+      fill: $amber600;
+    }
+  }
+
+  &__summary {
+    min-width: 0;
+  }
+
+  // The row/column switch itself is a Box prop (see the component); these only
+  // adjust spacing once it has stacked.
+  @media all and (max-width: $breakpoint-mobile) {
+    &__action {
+      margin-top: 12px;
+      width: 100%;
+      justify-content: space-between;
+    }
+  }
+}

--- a/src/components/stake/StakeStats.jsx
+++ b/src/components/stake/StakeStats.jsx
@@ -13,7 +13,6 @@ import {
 
 import format, { formattedNumber } from "utils/format";
 import { StakeType, ZERO } from "constants";
-import { reduceBnSum } from "utils/reduce";
 import { useVouchees } from "providers/VoucheesData";
 import { useMember } from "providers/MemberData";
 import { useModals } from "providers/ModalManager";
@@ -21,6 +20,7 @@ import { STAKE_MODAL } from "components/modals/StakeModal";
 import { AddressesAvatarBadgeRow } from "components/shared";
 import { Link } from "react-router-dom";
 import { useToken } from "hooks/useToken";
+import { useFrozenStake } from "hooks/useFrozenStake";
 
 export default function StakeStats() {
   const { open } = useModals();
@@ -28,13 +28,13 @@ export default function StakeStats() {
 
   const { data: member = {} } = useMember();
   const { data: vouchees = [] } = useVouchees();
+  // Shared with FrozenStakeAlert so the two readouts can't disagree.
+  const { overdueVouchees: defaultedVouchees, frozen: defaulted } = useFrozenStake();
 
   const { stakedBalance = ZERO, totalLockedStake = ZERO } = member;
 
   const withdrawableStake = stakedBalance - totalLockedStake;
   const borrowingVouchees = vouchees.filter((v) => v.locking > ZERO);
-  const defaultedVouchees = vouchees.filter((v) => v.isOverdue);
-  const defaulted = defaultedVouchees.map((v) => v.locking).reduce(reduceBnSum, ZERO);
 
   return (
     <Card className="StakeStats">

--- a/src/hooks/useFrozenStake.js
+++ b/src/hooks/useFrozenStake.js
@@ -1,0 +1,31 @@
+import { useMemo } from "react";
+
+import { ZERO } from "constants";
+import { reduceBnSum } from "utils/reduce";
+import { useVouchees } from "providers/VoucheesData";
+
+/**
+ * The connected member's staker-side delinquency exposure: which contacts they
+ * back are overdue, and how much of their own stake those contacts have frozen.
+ *
+ * Shared by StakeStats and FrozenStakeAlert so the two can't drift — the alert
+ * is what a member sees before they ever open the Stake tab.
+ */
+export function useFrozenStake() {
+  const { data: vouchees = [] } = useVouchees();
+
+  return useMemo(() => {
+    const overdueVouchees = vouchees.filter((v) => v.isOverdue);
+    const frozen = overdueVouchees.map((v) => v.locking ?? ZERO).reduce(reduceBnSum, ZERO);
+
+    return {
+      overdueVouchees,
+      count: overdueVouchees.length,
+      frozen,
+      // Only worth interrupting someone when real capital is affected: a
+      // contact can read as overdue while locking nothing (nothing borrowed
+      // against this member's vouch), which is not the member's problem.
+      hasFrozenStake: overdueVouchees.length > 0 && frozen > ZERO,
+    };
+  }, [vouchees]);
+}

--- a/src/hooks/useFrozenStake.test.js
+++ b/src/hooks/useFrozenStake.test.js
@@ -1,0 +1,59 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const useVouchees = vi.hoisted(() => vi.fn());
+vi.mock("providers/VoucheesData", () => ({ useVouchees }));
+
+import { useFrozenStake } from "hooks/useFrozenStake";
+
+const vouchee = (address, isOverdue, locking) => ({ address, isOverdue, locking });
+
+const render = () => renderHook(() => useFrozenStake()).result.current;
+
+describe("useFrozenStake", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("sums locked stake across overdue contacts only", () => {
+    useVouchees.mockReturnValue({
+      data: [
+        vouchee("0xa", true, 100n),
+        vouchee("0xb", false, 900n),
+        vouchee("0xc", true, 25n),
+      ],
+    });
+
+    const { count, frozen, hasFrozenStake, overdueVouchees } = render();
+    expect(count).toBe(2);
+    expect(frozen).toBe(125n);
+    expect(hasFrozenStake).toBe(true);
+    expect(overdueVouchees.map((v) => v.address)).toEqual(["0xa", "0xc"]);
+  });
+
+  it("stays quiet when nobody is overdue", () => {
+    useVouchees.mockReturnValue({ data: [vouchee("0xa", false, 500n)] });
+
+    const { count, frozen, hasFrozenStake } = render();
+    expect(count).toBe(0);
+    expect(frozen).toBe(0n);
+    expect(hasFrozenStake).toBe(false);
+  });
+
+  // An overdue contact who has borrowed nothing against THIS member's vouch
+  // freezes none of their capital — alerting there would be a false alarm.
+  it("does not flag frozen stake when overdue contacts lock nothing", () => {
+    useVouchees.mockReturnValue({ data: [vouchee("0xa", true, 0n)] });
+
+    const { count, frozen, hasFrozenStake } = render();
+    expect(count).toBe(1);
+    expect(frozen).toBe(0n);
+    expect(hasFrozenStake).toBe(false);
+  });
+
+  it("tolerates a missing locking field and an empty list", () => {
+    useVouchees.mockReturnValue({ data: [{ address: "0xa", isOverdue: true }] });
+    expect(render().frozen).toBe(0n);
+
+    useVouchees.mockReturnValue({ data: undefined });
+    expect(render().hasFrozenStake).toBe(false);
+  });
+});

--- a/src/hooks/useFrozenStakeAlert.js
+++ b/src/hooks/useFrozenStakeAlert.js
@@ -1,0 +1,57 @@
+import { useCallback, useMemo } from "react";
+import { useAccount } from "wagmi";
+
+import { useFrozenStake } from "hooks/useFrozenStake";
+import { DISMISSED_OVERDUE, useSettings } from "providers/Settings";
+
+/**
+ * Visibility + dismissal for FrozenStakeAlert.
+ *
+ * Dismissal records WHICH contacts were acknowledged rather than a "hidden"
+ * flag, so the alert stays honest: dismissing it keeps it away for the
+ * situation the member has seen, but a newly overdue contact makes it return.
+ * A plain boolean would silence the alert permanently on the first dismissal,
+ * which defeats the point of surfacing frozen capital at all.
+ *
+ * Kept out of useFrozenStake so StakeStats' Frozen block is never affected by
+ * a dismissal — that readout should always show the full picture.
+ */
+export function useFrozenStakeAlert() {
+  const { chain } = useAccount();
+  const { settings, setSetting } = useSettings();
+  const frozenStake = useFrozenStake();
+
+  const { overdueVouchees, hasFrozenStake } = frozenStake;
+  const chainId = chain?.id;
+
+  const addresses = useMemo(
+    () => overdueVouchees.map((v) => v.address?.toLowerCase()).filter(Boolean),
+    [overdueVouchees]
+  );
+
+  const dismissed = useMemo(
+    () => settings?.[DISMISSED_OVERDUE]?.[chainId] ?? [],
+    [settings, chainId]
+  );
+
+  // Only the contacts the member has not already acknowledged keep it visible.
+  const unseen = useMemo(
+    () => addresses.filter((address) => !dismissed.includes(address)),
+    [addresses, dismissed]
+  );
+
+  const dismiss = useCallback(() => {
+    if (!chainId) return;
+
+    setSetting(DISMISSED_OVERDUE, {
+      ...(settings?.[DISMISSED_OVERDUE] ?? {}),
+      [chainId]: addresses,
+    });
+  }, [chainId, settings, addresses, setSetting]);
+
+  return {
+    ...frozenStake,
+    visible: hasFrozenStake && unseen.length > 0,
+    dismiss,
+  };
+}

--- a/src/hooks/useFrozenStakeAlert.test.js
+++ b/src/hooks/useFrozenStakeAlert.test.js
@@ -1,0 +1,85 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const useFrozenStake = vi.hoisted(() => vi.fn());
+const useSettings = vi.hoisted(() => vi.fn());
+const useAccount = vi.hoisted(() => vi.fn());
+
+vi.mock("hooks/useFrozenStake", () => ({ useFrozenStake }));
+vi.mock("wagmi", () => ({ useAccount }));
+vi.mock("providers/Settings", () => ({
+  useSettings,
+  DISMISSED_OVERDUE: "dismissed-overdue",
+}));
+
+import { useFrozenStakeAlert } from "hooks/useFrozenStakeAlert";
+
+const A = "0xAaAaAaAa00000000000000000000000000000001";
+const B = "0xBbBbBbBb00000000000000000000000000000002";
+
+const setup = ({ overdue = [A], frozen = 100n, dismissed, setSetting = vi.fn() } = {}) => {
+  useAccount.mockReturnValue({ chain: { id: 8453 } });
+  useFrozenStake.mockReturnValue({
+    overdueVouchees: overdue.map((address) => ({ address })),
+    count: overdue.length,
+    frozen,
+    hasFrozenStake: overdue.length > 0 && frozen > 0n,
+  });
+  useSettings.mockReturnValue({
+    settings: dismissed ? { "dismissed-overdue": dismissed } : {},
+    setSetting,
+  });
+  return setSetting;
+};
+
+const render = () => renderHook(() => useFrozenStakeAlert()).result.current;
+
+describe("useFrozenStakeAlert", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("is visible when stake is frozen and nothing has been dismissed", () => {
+    setup();
+    expect(render().visible).toBe(true);
+  });
+
+  it("hides once the current overdue contacts have been dismissed", () => {
+    setup({ overdue: [A], dismissed: { 8453: [A.toLowerCase()] } });
+    expect(render().visible).toBe(false);
+  });
+
+  // The whole point of the alert is reach — a permanent dismissal would
+  // silence it forever, so a newly overdue contact has to bring it back.
+  it("returns when a new contact goes overdue after a dismissal", () => {
+    setup({ overdue: [A, B], dismissed: { 8453: [A.toLowerCase()] } });
+    expect(render().visible).toBe(true);
+  });
+
+  it("stays hidden when an acknowledged contact repays and leaves the set", () => {
+    setup({ overdue: [A], dismissed: { 8453: [A.toLowerCase(), B.toLowerCase()] } });
+    expect(render().visible).toBe(false);
+  });
+
+  it("keeps dismissals per chain", () => {
+    setup({ overdue: [A], dismissed: { 10: [A.toLowerCase()] } });
+    expect(render().visible).toBe(true);
+  });
+
+  it("records the acknowledged contacts (lowercased) without dropping other chains", () => {
+    const setSetting = setup({
+      overdue: [A, B],
+      dismissed: { 10: ["0xold"] },
+    });
+
+    render().dismiss();
+
+    expect(setSetting).toHaveBeenCalledWith("dismissed-overdue", {
+      10: ["0xold"],
+      8453: [A.toLowerCase(), B.toLowerCase()],
+    });
+  });
+
+  it("never shows when no stake is actually frozen", () => {
+    setup({ overdue: [A], frozen: 0n });
+    expect(render().visible).toBe(false);
+  });
+});

--- a/src/pages/CreditPages.jsx
+++ b/src/pages/CreditPages.jsx
@@ -1,6 +1,7 @@
 import { Layout } from "@unioncredit/ui";
 
 import { CreditSegmentedControl } from "components/shared/CreditSegmentedControl";
+import { FrozenStakeAlert } from "components/credit/FrozenStakeAlert";
 import BorrowPage from "pages/Borrow";
 import StakePage from "pages/Stake";
 import ContactsPage from "pages/Contacts";
@@ -43,6 +44,12 @@ export default function CreditPages({ page }) {
         maxw="653px"
         initialActive={initialActive}
       />
+
+      {/* Renders on every credit tab, so frozen stake is visible from Borrow —
+          the tab members land on — not only after opening Stake. */}
+      <Layout.Columned maxw="653px" p={0}>
+        <FrozenStakeAlert />
+      </Layout.Columned>
 
       {component}
     </Layout.Columned>

--- a/src/providers/Settings.jsx
+++ b/src/providers/Settings.jsx
@@ -14,6 +14,9 @@ const SettingsContext = createContext({
 });
 
 export const GASLESS_APPROVALS = "gasless-approvals";
+// { [chainId]: string[] } — overdue contacts whose frozen-stake alert the
+// member has dismissed. Stored per chain because vouchees are per chain.
+export const DISMISSED_OVERDUE = "dismissed-overdue";
 export const PROVIDING_FILTERS = "providing-filters";
 export const RECEIVING_FILTERS = "receiving-filters";
 export const PROVIDING_SORT = "providing-sort";


### PR DESCRIPTION
## Why
Pulled from the live indexer: **158 borrowers are overdue right now** (137 Optimism, 21 Base), and Optimism's protocol page shows **38,363 of 53,069 staked — 72% — frozen** backing them. Every frozen dollar is a staker's capital earning nothing.

## The gap (after auditing what already exists)
Most of the overdue surface is already built, and this PR deliberately does **not** duplicate it:
- Borrower side: `CreditStats` already has an overdue card state, "Xd Overdue", write-off badge, and calendar reminder ✅
- Staker detail: `StakeStats` already has a Frozen block with defaulter avatars; contacts rows already have overdue styling + status badges ✅

What was missing is **reach**: all of it lives on tabs you must navigate to. Members land on **Borrow**, which shows only their own credit — so a staker with frozen capital saw nothing until they happened to open Stake or Contacts.

## What this adds
- **`FrozenStakeAlert`** — renders above all three credit tabs when the member actually has stake frozen, showing the amount, the count, the faces, and a deep link to the existing `?filters=overdue` view.
- **`useFrozenStake`** — the calculation, now shared: `StakeStats` reads it too, so the alert and the Frozen block can't drift apart.
- Gated on **`frozen > 0`**, not just an overdue flag — a contact can be overdue while locking none of *this* member's stake, and interrupting someone over that is a false alarm (covered by a test).

## Verification
- **48/48 unit tests** (4 new for the hook: summing across overdue only, quiet when none, no-false-alarm at zero locked, missing/empty data) + 4/4 Anvil fork ✅
- `yarn lint` 0 errors · build clean ✅
- Rendered at 1440px and 390px via a throwaway data harness (reverted; the diff contains no harness). The **first mobile attempt was broken** — a CSS media query lost to `Box`'s own flex-direction prop and wrapped the heading one word per line; the row/column switch is now a prop, matching `CreditStats`.

## Not in this PR
Slices 2–3 of the delinquency loop — **web push** ("payment due in 3 days", "a contact you back went overdue") and email fallback. That's where the real leverage is, since it reaches people who aren't in the app; the PWA install flow just merged is the channel, and the indexer already computes `isOverdue` every 12h.